### PR TITLE
Update src/Sonata/Doctrine/Types/JsonType.php

### DIFF
--- a/src/Sonata/Doctrine/Types/JsonType.php
+++ b/src/Sonata/Doctrine/Types/JsonType.php
@@ -54,4 +54,9 @@ class JsonType extends Type
     {
         return $platform->getClobTypeDeclarationSQL($fieldDeclaration);
     }
+    
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }    
 }


### PR DESCRIPTION
The requiresSQLCommentHint function is required by the doctrine:schema / doctrine:migrations SQL generators to create the correct SQL comments in regards to this custom type.

The following SQL comment is required for each json field:

COMMENT '(DC2Type:json)'

Without this function, the json fields will be saved as normal plaintext and the comparator will always try to update them.

Referenced issue:
https://github.com/sonata-project/SonataUserBundle/issues/148
