### PR TITLE
Drop old versions of Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/dbal": "^2.2"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^2.8 || ^3.0"
     },
     "autoload": {
         "psr-4": { "Sonata\\Doctrine\\": "src/" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,8 +12,26 @@
          bootstrap="tests/bootstrap.php"
 >
     <testsuites>
-        <testsuite name="Sonata Doctrine Extensions ~ Test Suite">
-            <directory>./tests/</directory>
+        <testsuite name="sonata-doctrine-extensions Test Suite">
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./tests/</directory>
+                <directory>./DataFixtures/</directory>
+                <directory>./Resources/</directory>
+                <directory>./vendor/</directory>
+                <directory>./coverage/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+    <php>
+        <ini name="precision" value="8"/>
+    </php>
+
 </phpunit>


### PR DESCRIPTION
I am targetting this branch, because dropping versions of Symfony is major.

## Changelog
<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- compatibility with symfony 2.7 was dropped
```
