### PR TITLE
Drop old versions of php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         }
     ],
     "require": {
-        "php": "^5.3.2 || ^7.0",
+        "php": "^7.1",
         "doctrine/dbal": "^2.2"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "autoload": {
         "psr-4": { "Sonata\\Doctrine\\": "src/" }


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- support for old versions of php
```
