### PR TITLE
Use alias for AdapterInterface

### DIFF
--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -36,3 +36,10 @@ interface AdapterInterface
      */
     public function getUrlsafeIdentifier($model);
 }
+
+if (!interface_exists(\Sonata\CoreBundle\Model\Adapter\AdapterInterface::class)) {
+    class_alias(
+        __NAMESPACE__.'\AdapterInterface',
+        \Sonata\CoreBundle\Model\Adapter\AdapterInterface::class
+    );
+}


### PR DESCRIPTION
## Use class alias for AdapterInterface

With @greg0ire help.
I am targeting this branch, because it is a bug fix.

Fixes #108 

## Changelog
```markdown
### Fixed
- Use class alias for `AdapterInterface`
```