### PR TITLE
Trigger deprecated types autoload

### DIFF
--- a/src/Adapter/AdapterChain.php
+++ b/src/Adapter/AdapterChain.php
@@ -45,3 +45,5 @@ class AdapterChain implements AdapterInterface
         }
     }
 }
+
+class_exists(\Sonata\CoreBundle\Model\Adapter\AdapterChain::class);

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -36,3 +36,5 @@ interface AdapterInterface
      */
     public function getUrlsafeIdentifier($model);
 }
+
+interface_exists(\Sonata\CoreBundle\Model\Adapter\AdapterInterface::class);

--- a/src/Adapter/ORM/DoctrineORMAdapter.php
+++ b/src/Adapter/ORM/DoctrineORMAdapter.php
@@ -64,3 +64,5 @@ class DoctrineORMAdapter implements AdapterInterface
         return $this->getNormalizedIdentifier($entity);
     }
 }
+
+class_exists(\Sonata\CoreBundle\Model\Adapter\DoctrineORMAdapter::class);

--- a/src/Adapter/PHPCR/DoctrinePHPCRAdapter.php
+++ b/src/Adapter/PHPCR/DoctrinePHPCRAdapter.php
@@ -71,3 +71,5 @@ class DoctrinePHPCRAdapter implements AdapterInterface
         }
     }
 }
+
+class_exists(\Sonata\CoreBundle\Model\Adapter\DoctrinePHPCRAdapter::class);

--- a/src/Document/BaseDocumentManager.php
+++ b/src/Document/BaseDocumentManager.php
@@ -46,3 +46,5 @@ abstract class BaseDocumentManager extends BaseManager
         return $this->getObjectManager();
     }
 }
+
+class_exists(\Sonata\CoreBundle\Model\BaseDocumentManager::class);

--- a/src/Document/BasePHPCRManager.php
+++ b/src/Document/BasePHPCRManager.php
@@ -58,3 +58,5 @@ abstract class BasePHPCRManager extends BaseManager
         return $this->getObjectManager();
     }
 }
+
+class_exists(\Sonata\CoreBundle\Model\BasePHPCRManager::class);

--- a/src/Entity/BaseEntityManager.php
+++ b/src/Entity/BaseEntityManager.php
@@ -46,3 +46,5 @@ abstract class BaseEntityManager extends BaseManager
         return $this->getObjectManager();
     }
 }
+
+class_exists(\Sonata\CoreBundle\Model\BaseEntityManager::class);

--- a/src/Model/BaseManager.php
+++ b/src/Model/BaseManager.php
@@ -142,3 +142,5 @@ abstract class BaseManager implements ManagerInterface
         }
     }
 }
+
+class_exists(\Sonata\CoreBundle\Model\BaseManager::class);

--- a/src/Model/ManagerInterface.php
+++ b/src/Model/ManagerInterface.php
@@ -95,3 +95,5 @@ interface ManagerInterface
      */
     public function getConnection();
 }
+
+interface_exists(\Sonata\CoreBundle\Model\ManagerInterface::class);

--- a/src/Model/PageableManagerInterface.php
+++ b/src/Model/PageableManagerInterface.php
@@ -26,3 +26,5 @@ interface PageableManagerInterface
      */
     public function getPager(array $criteria, $page, $limit = 10, array $sort = []);
 }
+
+interface_exists(\Sonata\CoreBundle\Model\PageableManagerInterface::class);


### PR DESCRIPTION
## Subject

By loading the deprecated type, we make sure the class alias they
contains exist, so that code type hinting against the old type
accepts the new. This is necessary because type hinting does not trigger
autoload, since it usually does not need to.

Contrary to #107, the alias will not be created if sonata/core-bundle is not installed, which should not happen since code type hinting against an interface from that package is supposed to require it explicitely.

I am targeting this branch, because this is BC.

Fixes #108, Closes #107 

## Changelog

```markdown
### Fixed
- crash about type hinting issues with AdapterInterface
```