### PR TITLE
[BUG] fix invalid filename for config doctrine_phpcr.xml

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/SonataDoctrineExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/SonataDoctrineExtension.php
@@ -35,7 +35,7 @@ class SonataDoctrineExtension extends Extension
         }
 
         if (class_exists(DocumentManager::class)) {
-            $loader->load('doctine_phpcr.xml');
+            $loader->load('doctrine_phpcr.xml');
         }
     }
 }


### PR DESCRIPTION
### Fixed
invalid doctrine_phpcr config filename loading in SonataDoctrineExtension