### PR TITLE
Cast nullable value to string

### DIFF
--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -25,7 +25,7 @@ class JsonType extends Type
 
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        return json_decode($value, true);
+        return json_decode((string) $value, true);
     }
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform)


### PR DESCRIPTION
## Subject

This is because of the new `strict_types` policy

I am targeting this branch, because this is BC.

Fixes #116


## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- crash when decoding null value as JSON
```