### PR TITLE
Deprecate JsonType

### DIFF
--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,6 +1,11 @@
 UPGRADE 1.x
 ===========
 
+### `Sonata\Doctrine\Types\JsonType` has been deprecated
+
+`doctrine/dbal` has a native implementation, `Doctrine\DBAL\Types\JsonType`, that
+should be used instead.
+
 ### Tests
 
 All files under the ``Tests`` directory are now correctly handled as internal test classes. 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "doctrine/dbal": "^2.2"
+        "doctrine/dbal": "^2.6"
     },
     "require-dev": {
         "doctrine/common": "^2.7",

--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -16,6 +16,12 @@ namespace Sonata\Doctrine\Types;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\JsonType class is deprecated since 1.x in favor of '.
+    'Doctrine\DBAL\Types\JsonType, and will be removed in 2.0.',
+    E_USER_DEPRECATED
+);
+
 /**
  * Convert a value into a json string to be stored into the persistency layer.
  */

--- a/tests/Types/JsonTypeTest.php
+++ b/tests/Types/JsonTypeTest.php
@@ -16,6 +16,9 @@ namespace Sonata\Doctrine\Types\Tests;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group legacy
+ */
 class JsonTypeTest extends TestCase
 {
     public function setUp()


### PR DESCRIPTION
## Subject

`doctrine/dbal` has an implementation of this now.

I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `Sonata\Doctrine\Types\JsonType`, in favor of `Doctrine\DBAL\Types\JsonType`
```
