### PR TITLE
Move compiler pass from CoreBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "doctrine/orm": "^2.5",
         "doctrine/phpcr-odm": "^1.4 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^3.1",
         "symfony/dependency-injection": "^2.8 || ^3.3 || ^4.0",
         "symfony/expression-language": "^2.8 || ^3.3 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0",

--- a/src/Bridge/Symfony/Bundle/SonataDoctrineBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataDoctrineBundle.php
@@ -13,11 +13,18 @@ declare(strict_types=1);
 
 namespace Sonata\Doctrine\Bridge\Symfony\Bundle;
 
+use Sonata\Doctrine\Bridge\Symfony\DependencyInjection\Compiler\AdapterCompilerPass;
 use Sonata\Doctrine\Bridge\Symfony\DependencyInjection\SonataDoctrineExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class SonataDoctrineBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new AdapterCompilerPass());
+    }
+
     public function getPath()
     {
         return __DIR__.'/..';

--- a/src/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPass.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Doctrine\Bridge\Symfony\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+class AdapterCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('sonata.doctrine.model.adapter.chain')) {
+            return;
+        }
+
+        $definition = $container->findDefinition('sonata.doctrine.model.adapter.chain');
+
+        if ($container->has('doctrine')) {
+            $definition->addMethodCall('addAdapter', [new Reference('sonata.doctrine.adapter.doctrine_orm')]);
+        } else {
+            $container->removeDefinition('sonata.doctrine.adapter.doctrine_orm');
+        }
+
+        if ($container->has('doctrine_phpcr')) {
+            $definition->addMethodCall('addAdapter', [new Reference('sonata.doctrine.adapter.doctrine_phpcr')]);
+        } else {
+            $container->removeDefinition('sonata.doctrine.adapter.doctrine_phpcr');
+        }
+    }
+}

--- a/src/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPass.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 final class AdapterCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has('sonata.doctrine.model.adapter.chain')) {
             return;

--- a/src/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AdapterCompilerPass implements CompilerPassInterface
+final class AdapterCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {

--- a/tests/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPassTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPassTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Doctrine\Tests\Bridge\Symfony\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\Doctrine\Bridge\Symfony\DependencyInjection\Compiler\AdapterCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Ahmet Akbana <ahmetakbana@gmail.com>
+ */
+final class AdapterCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new AdapterCompilerPass());
+    }
+
+    public function testDefinitionsAdded()
+    {
+        $adapterChain = new Definition();
+        $this->setDefinition('sonata.doctrine.model.adapter.chain', $adapterChain);
+
+        $this->registerService('doctrine', 'foo');
+        $this->registerService('doctrine_phpcr', 'foo');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.doctrine.model.adapter.chain',
+            'addAdapter',
+            [new Reference('sonata.doctrine.adapter.doctrine_orm')]
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.doctrine.model.adapter.chain',
+            'addAdapter',
+            [new Reference('sonata.doctrine.adapter.doctrine_phpcr')]
+        );
+    }
+
+    public function testDefinitionsRemoved()
+    {
+        $adapterChain = new Definition();
+        $this->setDefinition('sonata.doctrine.model.adapter.chain', $adapterChain);
+
+        $this->registerService('sonata.doctrine.adapter.doctrine_orm', 'foo');
+        $this->registerService('sonata.doctrine.adapter.doctrine_phpcr', 'foo');
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sonata.doctrine.adapter.doctrine_orm');
+        $this->assertContainerBuilderNotHasService('sonata.doctrine.adapter.doctrine_phpcr');
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataCoreBundle/pull/679

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Adapters are not being injected on the adapter chain.
- `sonata_urlsafeid` twig filter is working again
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

This is related to https://github.com/sonata-project/SonataCoreBundle/pull/679
When this bridge bundle is not loaded, then this alias makes this work: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/src/CoreBundle/DependencyInjection/SonataCoreExtension.php#L80.

When you enable this bridge (as the deprecation message says), you start getting errors on the urlsafeid twig function, because the adapters are not loaded correctly.

Not sure if we should also do a PR on coreBundle to disable the compiler pass if this bundle is enabled. Probably we should, but we first need this PR, and lock this release on the coreBundle to avoid errors