### PR TITLE
Deprecated PageableManagerInterface

### DIFF
--- a/src/Model/PageableManagerInterface.php
+++ b/src/Model/PageableManagerInterface.php
@@ -24,7 +24,7 @@ use Sonata\DatagridBundle\Pager\PagerInterface;
 /**
  * @author Raphaël Benitte <benitteraphael@gmail.com>
  *
- * @deprecated since 1.x, to be removed in 43.0. Use Sonata\DatagridBundle\Pager\PageableInterface instead.
+ * @deprecated since 1.x, to be removed in 2.0. Use Sonata\DatagridBundle\Pager\PageableInterface instead.
  */
 interface PageableManagerInterface
 {

--- a/src/Model/PageableManagerInterface.php
+++ b/src/Model/PageableManagerInterface.php
@@ -15,8 +15,16 @@ namespace Sonata\Doctrine\Model;
 
 use Sonata\DatagridBundle\Pager\PagerInterface;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\PageableManagerInterface class is deprecated since 1.x in favor of '.
+    'Sonata\DatagridBundle\Pager\PageableInterface, and will be removed in 2.0.',
+    E_USER_DEPRECATED
+);
+
 /**
  * @author Raphaël Benitte <benitteraphael@gmail.com>
+ *
+ * @deprecated since 1.x, to be removed in 43.0. Use Sonata\DatagridBundle\Pager\PageableInterface instead.
  */
 interface PageableManagerInterface
 {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Moving the interface to this repo was wrong https://github.com/sonata-project/sonata-doctrine-extensions/pull/82.

We should use https://github.com/sonata-project/SonataDatagridBundle/blob/3.x/src/Pager/PageableInterface.php instead which does all pagination stuff.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `Sonata\Doctrine\Model\PageableManagerInterface`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
