### PR TITLE
Fix static analysis of ObjectRepository interface

### DIFF
--- a/src/Entity/BaseEntityManager.php
+++ b/src/Entity/BaseEntityManager.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\Doctrine\Entity;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
 use Sonata\Doctrine\Model\BaseManager;
 
 /**
@@ -46,6 +47,11 @@ abstract class BaseEntityManager extends BaseManager
     public function getEntityManager()
     {
         return $this->getObjectManager();
+    }
+
+    final protected function getRepository(): EntityRepository
+    {
+        return $this->getEntityManager()->getRepository($this->class);
     }
 }
 

--- a/tests/Entity/BaseEntityManagerTest.php
+++ b/tests/Entity/BaseEntityManagerTest.php
@@ -15,11 +15,16 @@ namespace Sonata\Doctrine\Tests\Entity;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityRepository;
 use PHPUnit\Framework\TestCase;
 use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class EntityManager extends BaseEntityManager
 {
+    public function getRepositoryFromBaseClass(): EntityRepository
+    {
+        return $this->getRepository();
+    }
 }
 
 final class BaseEntityManagerTest extends TestCase
@@ -66,5 +71,19 @@ final class BaseEntityManagerTest extends TestCase
         $manager = new EntityManager('classname', $registry);
 
         $manager->em;
+    }
+
+    public function testGetRepository(): void
+    {
+        $entityRepository = $this->createMock(EntityRepository::class);
+        $objectManager = $this->createMock(ObjectManager::class);
+        $objectManager->expects($this->once())->method('getRepository')->with('classname')->willReturn($entityRepository);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->expects($this->once())->method('getManagerForClass')->willReturn($objectManager);
+
+        $manager = new EntityManager('classname', $registry);
+        $repository = $manager->getRepositoryFromBaseClass();
+        $this->assertInstanceOf(EntityRepository::class, $repository);
     }
 }


### PR DESCRIPTION
## Subject

Make BaseEntityManager::getRepository returns an Doctrine\ORM\EntityManager

I am targeting this branch, because this should have no effect on executed code. The goal is to fix static analysis of php code as Doctrine\Common\Persistence\ObjectRepository interface does not have the createQueryBuilder method.

## Changelog

Fix BaseEntityManager::getRepository return type

```markdown
### Fixed
- Fix BaseEntityManager::getRepository return type
```
