### PR TITLE
fix using phpcr without orm

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPass.php
@@ -30,7 +30,7 @@ final class AdapterCompilerPass implements CompilerPassInterface
 
         $definition = $container->findDefinition('sonata.doctrine.model.adapter.chain');
 
-        if ($container->has('doctrine')) {
+        if ($this->isDoctrineOrmLoaded($container)) {
             $definition->addMethodCall('addAdapter', [new Reference('sonata.doctrine.adapter.doctrine_orm')]);
         } else {
             $container->removeDefinition('sonata.doctrine.adapter.doctrine_orm');
@@ -41,5 +41,10 @@ final class AdapterCompilerPass implements CompilerPassInterface
         } else {
             $container->removeDefinition('sonata.doctrine.adapter.doctrine_phpcr');
         }
+    }
+
+    private function isDoctrineOrmLoaded(ContainerBuilder $container): bool
+    {
+        return $container->has('doctrine') && $container->has('sonata.doctrine.adapter.doctrine_orm');
     }
 }

--- a/src/Bridge/Symfony/DependencyInjection/Compiler/MapperCompilerPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/MapperCompilerPass.php
@@ -27,7 +27,7 @@ final class MapperCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('doctrine')) {
+        if (!$this->isDoctrineOrmLoaded($container)) {
             $container->removeDefinition('sonata.doctrine.mapper');
 
             return;
@@ -75,5 +75,10 @@ final class MapperCompilerPass implements CompilerPassInterface
         }
 
         $collector->clear();
+    }
+
+    private function isDoctrineOrmLoaded(ContainerBuilder $container): bool
+    {
+        return $container->hasDefinition('doctrine') && $container->hasDefinition('sonata.doctrine.mapper');
     }
 }

--- a/tests/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPassTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPassTest.php
@@ -36,6 +36,7 @@ final class AdapterCompilerPassTest extends AbstractCompilerPassTestCase
 
         $this->registerService('doctrine', 'foo');
         $this->registerService('doctrine_phpcr', 'foo');
+        $this->registerService('sonata.doctrine.adapter.doctrine_orm', 'foo');
 
         $this->compile();
 
@@ -44,6 +45,25 @@ final class AdapterCompilerPassTest extends AbstractCompilerPassTestCase
             'addAdapter',
             [new Reference('sonata.doctrine.adapter.doctrine_orm')]
         );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.doctrine.model.adapter.chain',
+            'addAdapter',
+            [new Reference('sonata.doctrine.adapter.doctrine_phpcr')]
+        );
+    }
+
+    public function testDefinitionsAddedWithoutOrm()
+    {
+        $adapterChain = new Definition();
+        $this->setDefinition('sonata.doctrine.model.adapter.chain', $adapterChain);
+
+        $this->registerService('doctrine', 'foo');
+        $this->registerService('doctrine_phpcr', 'foo');
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sonata.doctrine.adapter.doctrine_orm');
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'sonata.doctrine.model.adapter.chain',

--- a/tests/Bridge/Symfony/DependencyInjection/Compiler/MapperCompilerPassTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/Compiler/MapperCompilerPassTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Doctrine\Tests\Bridge\Symfony\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\Doctrine\Bridge\Symfony\DependencyInjection\Compiler\MapperCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Ahmet Akbana <ahmetakbana@gmail.com>
+ */
+final class MapperCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new MapperCompilerPass());
+    }
+
+    public function testDefinitionsRemoved()
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sonata.doctrine.mapper');
+    }
+
+    public function testDefinitionsRemovedWithMapper()
+    {
+        $this->registerService('sonata.doctrine.mapper', 'foo');
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sonata.doctrine.mapper');
+    }
+
+    public function testDefinitionsRemovedWithDoctrine()
+    {
+        $this->registerService('doctrine', 'foo');
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sonata.doctrine.mapper');
+    }
+
+    public function testDefinitionsNotRemoved()
+    {
+        $this->registerService('sonata.doctrine.mapper', 'foo');
+        $this->registerService('doctrine', 'foo');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService('sonata.doctrine.mapper');
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

If we use PHPCR without ORM ( like https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle ) we have this 2 errors :
```
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]
You have requested a non-existent service "sonata.doctrine.mapper". 
```
And
```
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]
The service "sonata.doctrine.model.adapter.chain" has a dependency on a non-existent service "sonata.doctrine.adapter.doctrine_orm". 
```

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch with BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Using with only PHPCR without ORM
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
