### PR TITLE
fix(manager): remove final modifier for the method get repository

### DIFF
--- a/src/Entity/BaseEntityManager.php
+++ b/src/Entity/BaseEntityManager.php
@@ -49,7 +49,7 @@ abstract class BaseEntityManager extends BaseManager
         return $this->getObjectManager();
     }
 
-    final protected function getRepository(): EntityRepository
+    protected function getRepository(): EntityRepository
     {
         return $this->getEntityManager()->getRepository($this->class);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
cannot mock a final method for testing

Closes #142 

## Changelog

```markdown
### Changed
- Remove the final modifier for the `getRepository` method
```

### To do
- [x] removed the final modifier
- [x] updated tests for the base entity manager




