### PR TITLE
Add support symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
         "doctrine/phpcr-odm": "^1.4 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^3.1",
-        "symfony/dependency-injection": "^2.8 || ^3.3 || ^4.0",
-        "symfony/expression-language": "^2.8 || ^3.3 || ^4.0",
-        "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0",
-        "symfony/phpunit-bridge": "^4.2"
+        "symfony/dependency-injection": "^3.4 || ^4.2",
+        "symfony/expression-language": "^3.4 || ^4.2",
+        "symfony/framework-bundle": "^3.4 || ^4.2",
+        "symfony/phpunit-bridge": "^5.0"
     },
     "suggest": {
         "doctrine/orm": "If you use doctrine orm",

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "doctrine/phpcr-odm": "^1.4 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^3.1",
-        "symfony/dependency-injection": "^3.4 || ^4.2",
-        "symfony/expression-language": "^3.4 || ^4.2",
-        "symfony/framework-bundle": "^3.4 || ^4.2",
+        "symfony/dependency-injection": "^3.4 || ^4.2 || ^5.0",
+        "symfony/expression-language": "^3.4 || ^4.2 || ^5.0",
+        "symfony/framework-bundle": "^3.4 || ^4.2 || ^5.0",
         "symfony/phpunit-bridge": "^5.0"
     },
     "suggest": {

--- a/src/Model/BaseManager.php
+++ b/src/Model/BaseManager.php
@@ -80,7 +80,7 @@ abstract class BaseManager implements ManagerInterface
 
     public function findOneBy(array $criteria, array $orderBy = null)
     {
-        return $this->getRepository()->findOneBy($criteria, $orderBy);
+        return $this->getRepository()->findOneBy($criteria);
     }
 
     public function find($id)

--- a/src/Test/EntityManagerMockFactory.php
+++ b/src/Test/EntityManagerMockFactory.php
@@ -19,7 +19,6 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
-use Doctrine\ORM\Version;
 
 class EntityManagerMockFactory
 {
@@ -28,36 +27,30 @@ class EntityManagerMockFactory
      */
     public static function create(\PHPUnit\Framework\TestCase $test, \Closure $qbCallback, $fields)
     {
-        $query = $test->getMockBuilder(AbstractQuery::class)
-            ->disableOriginalConstructor()->getMock();
-        $query->expects($test->any())->method('execute')->will($test->returnValue(true));
+        $query = $test->createMock(AbstractQuery::class);
+        $query->method('execute')->willReturn(true);
 
-        if (Version::compare('2.5.0') < 1) {
-            $entityManager = $test->getMockBuilder(EntityManagerInterface::class)->getMock();
-            $qb = $test->getMockBuilder(QueryBuilder::class)->setConstructorArgs([$entityManager])->getMock();
-        } else {
-            $qb = $test->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
-        }
+        $qb = $test->createMock(QueryBuilder::class);
 
-        $qb->expects($test->any())->method('select')->will($test->returnValue($qb));
-        $qb->expects($test->any())->method('getQuery')->will($test->returnValue($query));
-        $qb->expects($test->any())->method('where')->will($test->returnValue($qb));
-        $qb->expects($test->any())->method('orderBy')->will($test->returnValue($qb));
-        $qb->expects($test->any())->method('andWhere')->will($test->returnValue($qb));
-        $qb->expects($test->any())->method('leftJoin')->will($test->returnValue($qb));
+        $qb->method('select')->willReturn($qb);
+        $qb->method('getQuery')->willReturn($query);
+        $qb->method('where')->willReturn($qb);
+        $qb->method('orderBy')->willReturn($qb);
+        $qb->method('andWhere')->willReturn($qb);
+        $qb->method('leftJoin')->willReturn($qb);
 
         $qbCallback($qb);
 
-        $repository = $test->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
-        $repository->expects($test->any())->method('createQueryBuilder')->will($test->returnValue($qb));
+        $repository = $test->createMock(EntityRepository::class);
+        $repository->method('createQueryBuilder')->willReturn($qb);
 
-        $metadata = $test->getMockBuilder(ClassMetadata::class)->getMock();
-        $metadata->expects($test->any())->method('getFieldNames')->will($test->returnValue($fields));
-        $metadata->expects($test->any())->method('getName')->will($test->returnValue('className'));
+        $metadata = $test->createMock(ClassMetadata::class);
+        $metadata->method('getFieldNames')->willReturn($fields);
+        $metadata->method('getName')->willReturn('className');
 
-        $em = $test->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
-        $em->expects($test->any())->method('getRepository')->will($test->returnValue($repository));
-        $em->expects($test->any())->method('getClassMetadata')->will($test->returnValue($metadata));
+        $em = $test->createMock(EntityManager::class);
+        $em->method('getRepository')->willReturn($repository);
+        $em->method('getClassMetadata')->willReturn($metadata);
 
         return $em;
     }

--- a/tests/Adapter/ORM/DoctrineORMAdapterTest.php
+++ b/tests/Adapter/ORM/DoctrineORMAdapterTest.php
@@ -62,7 +62,7 @@ final class DoctrineORMAdapterTest extends TestCase
         $unitOfWork->expects($this->once())->method('isInIdentityMap')->willReturn(false);
 
         $manager = $this->createMock(EntityManagerInterface::class);
-        $manager->expects($this->any())->method('getUnitOfWork')->willReturn($unitOfWork);
+        $manager->method('getUnitOfWork')->willReturn($unitOfWork);
 
         $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->once())->method('getManagerForClass')->willReturn($manager);
@@ -82,7 +82,7 @@ final class DoctrineORMAdapterTest extends TestCase
         $unitOfWork->expects($this->once())->method('getEntityIdentifier')->willReturn($data);
 
         $manager = $this->createMock(EntityManagerInterface::class);
-        $manager->expects($this->any())->method('getUnitOfWork')->willReturn($unitOfWork);
+        $manager->method('getUnitOfWork')->willReturn($unitOfWork);
 
         $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->once())->method('getManagerForClass')->willReturn($manager);

--- a/tests/Adapter/PHPCR/DoctrinePHPCRAdapterTest.php
+++ b/tests/Adapter/PHPCR/DoctrinePHPCRAdapterTest.php
@@ -85,11 +85,11 @@ final class DoctrinePHPCRAdapterTest extends TestCase
         $metadata->reflFields['path'] = new \ReflectionProperty(MyDocument::class, 'path');
 
         $manager = $this->getMockBuilder(DocumentManager::class)->disableOriginalConstructor()->getMock();
-        $manager->expects($this->any())->method('contains')->willReturn(true);
-        $manager->expects($this->any())->method('getClassMetadata')->willReturn($metadata);
+        $manager->method('contains')->willReturn(true);
+        $manager->method('getClassMetadata')->willReturn($metadata);
 
         $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects($this->any())->method('getManagerForClass')->willReturn($manager);
+        $registry->method('getManagerForClass')->willReturn($manager);
 
         $adapter = new DoctrinePHPCRAdapter($registry);
 

--- a/tests/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPassTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPassTest.php
@@ -36,6 +36,7 @@ final class AdapterCompilerPassTest extends AbstractCompilerPassTestCase
 
         $this->registerService('doctrine', 'foo');
         $this->registerService('doctrine_phpcr', 'foo');
+        $this->registerService('sonata.doctrine.adapter.doctrine_phpcr', 'foo');
         $this->registerService('sonata.doctrine.adapter.doctrine_orm', 'foo');
 
         $this->compile();
@@ -60,6 +61,7 @@ final class AdapterCompilerPassTest extends AbstractCompilerPassTestCase
 
         $this->registerService('doctrine', 'foo');
         $this->registerService('doctrine_phpcr', 'foo');
+        $this->registerService('sonata.doctrine.adapter.doctrine_phpcr', 'foo');
 
         $this->compile();
 

--- a/tests/Mapper/ORM/DoctrineORMMapperTest.php
+++ b/tests/Mapper/ORM/DoctrineORMMapperTest.php
@@ -27,7 +27,7 @@ class DoctrineORMMapperTest extends TestCase
 
     public function setUp()
     {
-        $this->metadata = $this->createMock(ClassMetadataInfo::class, [], [], '', false);
+        $this->metadata = $this->createMock(ClassMetadataInfo::class);
     }
 
     public function testLoadDiscriminators(): void

--- a/tests/Types/JsonTypeTest.php
+++ b/tests/Types/JsonTypeTest.php
@@ -15,6 +15,7 @@ namespace Sonata\Doctrine\Types\Tests;
 
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\TestCase;
+use Sonata\Doctrine\Types\JsonType;
 
 /**
  * @group legacy
@@ -24,9 +25,9 @@ class JsonTypeTest extends TestCase
     public function setUp()
     {
         if (Type::hasType('json')) {
-            Type::overrideType('json', 'Sonata\Doctrine\Types\JsonType');
+            Type::overrideType('json', JsonType::class);
         } else {
-            Type::addType('json', 'Sonata\Doctrine\Types\JsonType');
+            Type::addType('json', JsonType::class);
         }
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

The change in the BaseManager is because [`ObjectRepository::findOneBy`](https://github.com/doctrine/persistence/blob/1.1.x/lib/Doctrine/Common/Persistence/ObjectRepository.php#L53) only receives one parameter.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for Symfony 5
### Removed
- Support for Symfony < 3.4
- Support for Symfony >= 4, < 4.2
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
