### PR TITLE
Add deprecation for findOneBy with two arguments

### DIFF
--- a/src/Model/BaseManager.php
+++ b/src/Model/BaseManager.php
@@ -80,6 +80,13 @@ abstract class BaseManager implements ManagerInterface
 
     public function findOneBy(array $criteria, array $orderBy = null)
     {
+        if (null !== $orderBy) {
+            @trigger_error(
+                'The $orderBy argument of '.__METHOD__.' is deprecated since sonata-project/doctrine-extensions 1.x, to be removed in 2.0.',
+                E_USER_DEPRECATED
+            );
+        }
+
         return $this->getRepository()->findOneBy($criteria);
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

I should have included this in https://github.com/sonata-project/sonata-doctrine-extensions/pull/152

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Passing a second argument to `BaseManager::findOneBy`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
