### PR TITLE
Make OptionsBuilder API more explicit

### DIFF
--- a/src/Mapper/Builder/OptionsBuilder.php
+++ b/src/Mapper/Builder/OptionsBuilder.php
@@ -15,15 +15,42 @@ namespace Sonata\Doctrine\Mapper\Builder;
 
 final class OptionsBuilder
 {
+    private const ONE_TO_ONE = 'one_to_one';
+    private const ONE_TO_MANY = 'one_to_many';
+    private const MANY_TO_ONE = 'many_to_one';
+    private const MANY_TO_MANY = 'many_to_many';
+
     /**
      * @var array<string, mixed>
      */
     private $options = [];
 
-    private function __construct()
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * NEXT_MAJOR: Make the arguments mandatory.
+     */
+    private function __construct(string $type = null, string $fieldName = null, string $targetEntity = null)
     {
+        $this->type = $type;
+
+        if (null !== $fieldName) {
+            $this->options['fieldName'] = $fieldName;
+        }
+
+        if (null !== $targetEntity) {
+            $this->options['targetEntity'] = $targetEntity;
+        }
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-extensions 1.x, to be removed in 2.0.
+     */
     public static function create(): self
     {
         return new self();
@@ -32,6 +59,121 @@ final class OptionsBuilder
     public function add(string $key, $value): self
     {
         $this->options[$key] = $value;
+
+        return $this;
+    }
+
+    public static function createOneToOne(string $fieldName, string $targetEntity): self
+    {
+        return new self(self::ONE_TO_ONE, $fieldName, $targetEntity);
+    }
+
+    public static function createOneToMany(string $fieldName, string $targetEntity): self
+    {
+        return new self(self::ONE_TO_MANY, $fieldName, $targetEntity);
+    }
+
+    public static function createManyToOne(string $fieldName, string $targetEntity): self
+    {
+        return new self(self::MANY_TO_ONE, $fieldName, $targetEntity);
+    }
+
+    public static function createManyToMany(string $fieldName, string $targetEntity): self
+    {
+        return new self(self::MANY_TO_MANY, $fieldName, $targetEntity);
+    }
+
+    public function mappedBy(string $mappedBy): self
+    {
+        if (!\in_array($this->type, [self::ONE_TO_MANY, self::ONE_TO_ONE, self::MANY_TO_MANY], true)) {
+            throw new \RuntimeException(
+                'Invalid option, mappedBy only applies to one-to-many and one-to-one associations'
+            );
+        }
+
+        $this->options['mappedBy'] = $mappedBy;
+
+        return $this;
+    }
+
+    public function inversedBy(string $inversedBy): self
+    {
+        if (!\in_array($this->type, [self::ONE_TO_ONE, self::MANY_TO_ONE, self::MANY_TO_MANY], true)) {
+            throw new \RuntimeException(
+                'Invalid option: inversedBy only applies to one-to-one, many-to-one or many-to-many associations'
+            );
+        }
+
+        $this->options['inversedBy'] = $inversedBy;
+
+        return $this;
+    }
+
+    public function addJoinTable(string $name, array $joinColumns, array $inverseJoinColumns): self
+    {
+        if (self::MANY_TO_MANY !== $this->type) {
+            throw new \RuntimeException('Invalid mapping, joinTables only apply to many-to-many associations');
+        }
+
+        $this->options['joinTable'] = [
+            'name' => $name,
+            'joinColumns' => $joinColumns,
+            'inverseJoinColumns' => $inverseJoinColumns,
+        ];
+
+        return $this;
+    }
+
+    public function addOrder(string $field, string $orientation): self
+    {
+        if (!\in_array($this->type, [self::ONE_TO_MANY, self::MANY_TO_MANY], true)) {
+            throw new \RuntimeException(
+                'Invalid option: orderBy only applies to one-to-many or many-to-many associations'
+            );
+        }
+
+        if (!isset($this->options['orderBy'])) {
+            $this->options['orderBy'] = [];
+        }
+
+        $this->options['orderBy'] = array_merge($this->options['orderBy'], [$field => $orientation]);
+
+        return $this;
+    }
+
+    public function addJoin(array $joinColumn): self
+    {
+        if (!\in_array($this->type, [self::MANY_TO_ONE, self::ONE_TO_ONE], true)) {
+            throw new \RuntimeException(
+                'Invalid option, joinColumns only apply to many-to-one and one-to-one associations'
+            );
+        }
+
+        if (!isset($this->options['joinColumns'])) {
+            $this->options['joinColumns'] = [];
+        }
+
+        $this->options['joinColumns'][] = $joinColumn;
+
+        return $this;
+    }
+
+    public function cascade(array $value): self
+    {
+        $this->options['cascade'] = $value;
+
+        return $this;
+    }
+
+    public function orphanRemoval(): self
+    {
+        if (!\in_array($this->type, [self::ONE_TO_ONE, self::ONE_TO_MANY], true)) {
+            throw new \RuntimeException(
+                'Invalid option, orphanRemoval only apply to one-to-one and one-to-many associations'
+            );
+        }
+
+        $this->options['orphanRemoval'] = true;
 
         return $this;
     }

--- a/src/Mapper/Builder/OptionsBuilder.php
+++ b/src/Mapper/Builder/OptionsBuilder.php
@@ -109,6 +109,24 @@ final class OptionsBuilder
         return $this;
     }
 
+    /**
+     * @param array{
+     *     name: string,
+     *     referencedColumnName: string,
+     *     unique?: bool,
+     *     nullable?: bool,
+     *     onDelete?: string,
+     *     columnDefinition?: string
+     * }[] $joinColumns
+     * @param array{
+     *     name: string,
+     *     referencedColumnName: string,
+     *     unique?: bool,
+     *     nullable?: bool,
+     *     onDelete?: string,
+     *     columnDefinition?: string
+     * }[] $inverseJoinColumns
+     */
     public function addJoinTable(string $name, array $joinColumns, array $inverseJoinColumns): self
     {
         if (self::MANY_TO_MANY !== $this->type) {
@@ -124,6 +142,9 @@ final class OptionsBuilder
         return $this;
     }
 
+    /**
+     * @param 'ASC'|'DESC' $orientation
+     */
     public function addOrder(string $field, string $orientation): self
     {
         if (!\in_array($this->type, [self::ONE_TO_MANY, self::MANY_TO_MANY], true)) {
@@ -141,6 +162,16 @@ final class OptionsBuilder
         return $this;
     }
 
+    /**
+     * @param array{
+     *     name: string,
+     *     referencedColumnName: string,
+     *     unique?: bool,
+     *     nullable?: bool,
+     *     onDelete?: string,
+     *     columnDefinition?: string
+     * } $joinColumn
+     */
     public function addJoin(array $joinColumn): self
     {
         if (!\in_array($this->type, [self::MANY_TO_ONE, self::ONE_TO_ONE], true)) {
@@ -158,6 +189,9 @@ final class OptionsBuilder
         return $this;
     }
 
+    /**
+     * @psalm-param list<'persist'|'remove'|'merge'|'detach'|'refresh'|'all'> $value
+     */
     public function cascade(array $value): self
     {
         $this->options['cascade'] = $value;

--- a/tests/Mapper/Builder/OptionsBuilderTest.php
+++ b/tests/Mapper/Builder/OptionsBuilderTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Doctrine\Tests\Mapper\Builder;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
+
+final class OptionsBuilderTest extends TestCase
+{
+    public function testOneToOne(): void
+    {
+        $builder = OptionsBuilder::createOneToOne('field', 'App\Entity\Address');
+
+        $this->assertSame([
+            'fieldName' => 'field',
+            'targetEntity' => 'App\Entity\Address',
+        ], $builder->getOptions());
+    }
+
+    public function testCreateManyToOne(): void
+    {
+        $builder = OptionsBuilder::createManyToOne('address', 'App\Entity\Address');
+
+        $this->assertSame([
+            'fieldName' => 'address',
+            'targetEntity' => 'App\Entity\Address',
+        ], $builder->getOptions());
+    }
+
+    public function testCreateOneToMany(): void
+    {
+        $builder = OptionsBuilder::createOneToMany('features', 'App\Entity\Feature');
+
+        $this->assertSame([
+            'fieldName' => 'features',
+            'targetEntity' => 'App\Entity\Feature',
+        ], $builder->getOptions());
+    }
+
+    public function testCreateManyToMany(): void
+    {
+        $builder = OptionsBuilder::createManyToMany('groups', 'App\Entity\Group');
+
+        $this->assertSame([
+            'fieldName' => 'groups',
+            'targetEntity' => 'App\Entity\Group',
+        ], $builder->getOptions());
+    }
+
+    public function testJoinTable(): void
+    {
+        $builder = OptionsBuilder::createManyToMany('groups', 'App\Entity\Group')
+            ->addJoinTable('user_group', [[
+                'name' => 'user_id',
+                'referencedColumnName' => 'id',
+                'onDelete' => 'CASCADE',
+            ]], [[
+                'name' => 'group_id',
+                'referencedColumnName' => 'id',
+                'onDelete' => 'CASCADE',
+            ]])
+        ;
+
+        $this->assertSame([
+            'fieldName' => 'groups',
+            'targetEntity' => 'App\Entity\Group',
+            'joinTable' => [
+                'name' => 'user_group',
+                'joinColumns' => [
+                    [
+                        'name' => 'user_id',
+                        'referencedColumnName' => 'id',
+                        'onDelete' => 'CASCADE',
+                    ],
+                ],
+                'inverseJoinColumns' => [[
+                    'name' => 'group_id',
+                    'referencedColumnName' => 'id',
+                    'onDelete' => 'CASCADE',
+                ]],
+            ],
+        ], $builder->getOptions());
+    }
+
+    public function testCascade(): void
+    {
+        $builder = OptionsBuilder::createOneToMany('groups', 'App\Entity\Group')
+            ->cascade(['persist', 'refresh']);
+
+        $this->assertSame([
+            'fieldName' => 'groups',
+            'targetEntity' => 'App\Entity\Group',
+            'cascade' => ['persist', 'refresh'],
+        ], $builder->getOptions());
+    }
+
+    public function testOrphanRemoval(): void
+    {
+        $builder = OptionsBuilder::createOneToMany('groups', 'App\Entity\Group')
+            ->orphanRemoval();
+
+        $this->assertSame([
+            'fieldName' => 'groups',
+            'targetEntity' => 'App\Entity\Group',
+            'orphanRemoval' => true,
+        ], $builder->getOptions());
+    }
+
+    public function testOrphanRemovalThrowsExceptionOnInvalidMapping(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        OptionsBuilder::createManyToOne('groups', 'App\Entity\Group')
+            ->orphanRemoval();
+    }
+
+    public function testAddJoin(): void
+    {
+        $builder = OptionsBuilder::createOneToOne('groups', 'App\Entity\Group')
+            ->addJoin([
+                'name' => 'parent_id',
+                'referencedColumnName' => 'id',
+                'onDelete' => 'CASCADE',
+            ])
+            ->addJoin([
+                'name' => 'another_parent_id',
+                'referencedColumnName' => 'id',
+                'onDelete' => 'CASCADE',
+            ])
+        ;
+
+        $this->assertSame([
+            'fieldName' => 'groups',
+            'targetEntity' => 'App\Entity\Group',
+            'joinColumns' => [[
+                'name' => 'parent_id',
+                'referencedColumnName' => 'id',
+                'onDelete' => 'CASCADE',
+            ],
+            [
+                'name' => 'another_parent_id',
+                'referencedColumnName' => 'id',
+                'onDelete' => 'CASCADE',
+
+            ], ],
+        ], $builder->getOptions());
+    }
+
+    public function testAddJoinThrowsExceptionOnInvalidMapping(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        OptionsBuilder::createOneToMany('groups', 'App\Entity\Group')
+            ->addJoin([
+                'name' => 'parent_id',
+                'referencedColumnName' => 'id',
+                'onDelete' => 'CASCADE',
+            ])
+            ->addJoin([
+                'name' => 'another_parent_id',
+                'referencedColumnName' => 'id',
+                'onDelete' => 'CASCADE',
+            ])
+        ;
+    }
+
+    public function testOrderBy(): void
+    {
+        $builder = OptionsBuilder::createOneToMany('groups', 'App\Entity\Group')
+            ->addOrder('position', 'ASC')
+            ->addOrder('name', 'DESC')
+        ;
+
+        $this->assertSame([
+            'fieldName' => 'groups',
+            'targetEntity' => 'App\Entity\Group',
+            'orderBy' => [
+                'position' => 'ASC',
+                'name' => 'DESC',
+            ],
+        ], $builder->getOptions());
+    }
+
+    public function testOrderByThrowsExceptionOnInvalidMapping(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        OptionsBuilder::createOneToOne('groups', 'App\Entity\Group')
+            ->addOrder('name', 'DESC')
+        ;
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testCreate(): void
+    {
+        $builder = OptionsBuilder::create()
+            ->add('foo', 'bar')
+            ->add('bar', 'foo')
+            ->add('foobar', [
+                'foo', 'bar',
+            ]);
+
+        $this->assertSame([
+            'foo' => 'bar',
+            'bar' => 'foo',
+            'foobar' => [
+                'foo', 'bar',
+            ],
+        ], $builder->getOptions());
+    }
+}


### PR DESCRIPTION
## Subject

The idea (https://github.com/sonata-project/sonata-doctrine-extensions/issues/172) is to create some methods that make using `OptionsBuilder` more developer-friendly. 

The checks are based on [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/reference/association-mapping.html#association-mapping). 

I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #172

## Changelog

```markdown
### Added
- Added some explicit methods to `OptionsBuilder`
### Deprecated
- `OptionsBuilder::create` method
```
I added:

- `createOneToOne`
- `createOneToMany`
- `createManyToOne`
- `createManyToMany`
- `mappedBy `
- `inversedBy`
- `addJoinTable`
- `addOrder`
- `addJoin`
- `cascade`
- `orphanRemoval `