### PR TITLE
Fix addAssociation, addDiscriminatorColumn and addOverride on DoctrineCollector

### DIFF
--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,6 +1,16 @@
 UPGRADE 1.x
 ===========
 
+### `Sonata\Doctrine\Mapper\DoctrineCollector`
+
+Deprecated passing other type than integer as argument 2 for `addInheritanceType()`.
+
+### `Sonata\Doctrine\Mapper\ORM\DoctrineORMMapper`
+
+Deprecated passing other type than array as argument 3 for `addAssociation()`.
+Deprecated passing other type than array as argument 2 for `addDiscriminatorColumn()`.
+Deprecated passing other type than array as argument 3 for `addOverride()`.
+
 ### `Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle`
 
 Deprecated `Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle`. Use `Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle`

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "require-dev": {
         "doctrine/common": "^2.7 || ^3.0",
+        "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/phpcr-odm": "^1.5.2",
         "jackalope/jackalope-doctrine-dbal": "^1.0",

--- a/src/Mapper/DoctrineCollector.php
+++ b/src/Mapper/DoctrineCollector.php
@@ -95,12 +95,23 @@ final class DoctrineCollector
     public function addDiscriminatorColumn(string $class, ColumnDefinitionBuilder $columnDef): void
     {
         if (!isset($this->discriminatorColumns[$class])) {
-            $this->discriminatorColumns[$class] = $columnDef;
+            $this->discriminatorColumns[$class] = $columnDef->getOptions();
         }
     }
 
-    public function addInheritanceType(string $class, string $type): void
+    /**
+     * @param int $type
+     */
+    public function addInheritanceType(string $class, $type): void
     {
+        // NEXT_MAJOR: Move int check to method signature
+        if (!\is_int($type)) {
+            @trigger_error(sprintf(
+                'Passing other type than int as argument 2 for method %s() is deprecated since sonata-project/doctrine-extensions 1.x. It will accept only int in version 2.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         if (!isset($this->inheritanceTypes[$class])) {
             $this->inheritanceTypes[$class] = $type;
         }
@@ -116,7 +127,7 @@ final class DoctrineCollector
             $this->associations[$class][$type] = [];
         }
 
-        $this->associations[$class][$type][] = $options;
+        $this->associations[$class][$type][] = $options->getOptions();
     }
 
     /**
@@ -165,7 +176,7 @@ final class DoctrineCollector
             $this->overrides[$class][$type] = [];
         }
 
-        $this->overrides[$class][$type][] = $options;
+        $this->overrides[$class][$type][] = $options->getOptions();
     }
 
     public function getAssociations(): array

--- a/src/Mapper/ORM/DoctrineORMMapper.php
+++ b/src/Mapper/ORM/DoctrineORMMapper.php
@@ -19,8 +19,6 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use InvalidArgumentException;
 use ReflectionException;
 use RuntimeException;
-use Sonata\Doctrine\Mapper\Builder\ColumnDefinitionBuilder;
-use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
 
 final class DoctrineORMMapper implements EventSubscriber
 {
@@ -66,13 +64,24 @@ final class DoctrineORMMapper implements EventSubscriber
         ];
     }
 
-    public function addAssociation(string $class, string $field, OptionsBuilder $options): void
+    /**
+     * @param array $options
+     */
+    public function addAssociation(string $class, string $type, $options): void
     {
+        // NEXT_MAJOR: Move array check to method signature
+        if (!\is_array($options)) {
+            @trigger_error(sprintf(
+                'Passing other type than array as argument 3 for method %s() is deprecated since sonata-project/doctrine-extensions 1.x. It will accept only array in version 2.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         if (!isset($this->associations[$class])) {
             $this->associations[$class] = [];
         }
 
-        $this->associations[$class][$field] = $options->getOptions();
+        $this->associations[$class][$type] = $options;
     }
 
     /**
@@ -92,10 +101,21 @@ final class DoctrineORMMapper implements EventSubscriber
         }
     }
 
-    public function addDiscriminatorColumn(string $class, ColumnDefinitionBuilder $columnDef): void
+    /**
+     * @param array $columnDef
+     */
+    public function addDiscriminatorColumn(string $class, $columnDef): void
     {
+        // NEXT_MAJOR: Move array check to method signature
+        if (!\is_array($columnDef)) {
+            @trigger_error(sprintf(
+                'Passing other type than array as argument 2 for method %s() is deprecated since sonata-project/doctrine-extensions 1.x. It will accept only array in version 2.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         if (!isset($this->discriminatorColumns[$class])) {
-            $this->discriminatorColumns[$class] = $columnDef->getOptions();
+            $this->discriminatorColumns[$class] = $columnDef;
         }
     }
 
@@ -145,13 +165,24 @@ final class DoctrineORMMapper implements EventSubscriber
         $this->uniques[$class][$name] = $columns;
     }
 
-    public function addOverride(string $class, string $type, OptionsBuilder $options): void
+    /**
+     * @param array $options
+     */
+    public function addOverride(string $class, string $type, $options): void
     {
+        // NEXT_MAJOR: Move array check to method signature
+        if (!\is_array($options)) {
+            @trigger_error(sprintf(
+                'Passing other type than array as argument 3 for method %s() is deprecated since sonata-project/doctrine-extensions 1.x. It will accept only array in version 2.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         if (!isset($this->overrides[$class])) {
             $this->overrides[$class] = [];
         }
 
-        $this->overrides[$class][$type] = $options->getOptions();
+        $this->overrides[$class][$type] = $options;
     }
 
     public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs): void

--- a/tests/App/Entity/TestEntity.php
+++ b/tests/App/Entity/TestEntity.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Doctrine\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+abstract class TestEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    private $relation;
+
+    /**
+     * @ORM\Column(type="string", length=200)
+     */
+    private $property;
+}

--- a/tests/App/Entity/TestInheritanceEntity.php
+++ b/tests/App/Entity/TestInheritanceEntity.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Doctrine\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class TestInheritanceEntity extends TestEntity
+{
+}

--- a/tests/App/Entity/TestRelatedEntity.php
+++ b/tests/App/Entity/TestRelatedEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Doctrine\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class TestRelatedEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+}

--- a/tests/App/Kernel.php
+++ b/tests/App/Kernel.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Doctrine\Tests\App;
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle;
+use Sonata\Doctrine\Tests\App\Entity\TestEntity;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+final class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        return [
+            new DoctrineBundle(),
+            new FrameworkBundle(),
+            new SonataDoctrineBundle(),
+        ];
+    }
+
+    public function getCacheDir(): string
+    {
+        return $this->getBaseDir().'cache';
+    }
+
+    public function getLogDir(): string
+    {
+        return $this->getBaseDir().'log';
+    }
+
+    public function getProjectDir(): string
+    {
+        return __DIR__;
+    }
+
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
+    {
+        $container->loadFromExtension('framework', [
+            'test' => true,
+            'router' => ['utf8' => true],
+            'secret' => 'secret',
+        ]);
+
+        $container->loadFromExtension('doctrine', [
+            'dbal' => ['url' => 'sqlite://:memory:'],
+            'orm' => [
+                'mappings' => [
+                    'Entity' => [
+                        'type' => 'annotation',
+                        'dir' => '%kernel.project_dir%/Entity',
+                        'prefix' => TestEntity::class,
+                        'is_bundle' => false,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    {
+    }
+
+    private function getBaseDir(): string
+    {
+        return sys_get_temp_dir().'/sonata-doctrine-extensions/var/';
+    }
+}

--- a/tests/Bridge/Symfony/DependencyInjection/Compiler/MapperCompilerPassTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/Compiler/MapperCompilerPassTest.php
@@ -15,6 +15,11 @@ namespace Sonata\Doctrine\Tests\Bridge\Symfony\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Sonata\Doctrine\Bridge\Symfony\DependencyInjection\Compiler\MapperCompilerPass;
+use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
+use Sonata\Doctrine\Mapper\DoctrineCollector;
+use Sonata\Doctrine\Mapper\ORM\DoctrineORMMapper;
+use Sonata\Doctrine\Tests\App\Entity\TestEntity;
+use Sonata\Doctrine\Tests\App\Entity\TestRelatedEntity;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -60,5 +65,33 @@ final class MapperCompilerPassTest extends AbstractCompilerPassTestCase
         $this->compile();
 
         $this->assertContainerBuilderHasService('sonata.doctrine.mapper');
+    }
+
+    public function testAssociationMapping(): void
+    {
+        $definition = $this->registerService('sonata.doctrine.mapper', DoctrineORMMapper::class);
+        $definition->setPublic(true);
+
+        $this->registerService('doctrine', 'foo');
+
+        $options = OptionsBuilder::createManyToOne('relation', TestRelatedEntity::class)
+            ->add('joinColumns', [['referencedColumnName' => 'id']]);
+
+        $collector = DoctrineCollector::getInstance();
+        $collector->addAssociation(TestEntity::class, 'mapManyToOne', $options);
+
+        $this->compile();
+
+        $compiledMapper = $this->container->get('sonata.doctrine.mapper');
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.doctrine.mapper',
+            'addAssociation',
+            [TestEntity::class, 'mapManyToOne', [$options->getOptions()]]
+        );
+
+        $this->assertInstanceOf(DoctrineORMMapper::class, $compiledMapper);
+
+        $collector->clear();
     }
 }

--- a/tests/Mapper/DoctrineCollectorTest.php
+++ b/tests/Mapper/DoctrineCollectorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Doctrine\Tests\Mapper;
 
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use PHPUnit\Framework\TestCase;
 use Sonata\Doctrine\Mapper\Builder\ColumnDefinitionBuilder;
 use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
@@ -46,7 +47,7 @@ class DoctrineCollectorTest extends TestCase
         $collector = DoctrineCollector::getInstance();
         $collector->addIndex(stdClass::class, 'name', ['column']);
         $collector->addUnique(stdClass::class, 'name', ['column']);
-        $collector->addInheritanceType(stdClass::class, 'type');
+        $collector->addInheritanceType(stdClass::class, ClassMetadataInfo::INHERITANCE_TYPE_SINGLE_TABLE);
         $collector->addDiscriminatorColumn(stdClass::class, ColumnDefinitionBuilder::create()
             ->add('columnDef', ''));
         $collector->addAssociation(stdClass::class, 'type', OptionsBuilder::create()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because without this fix it is imposible to use this feature.

I am trying to use this bundle to generate dynamic mapping here: https://github.com/Runroom/RunroomSamplesBundle/blob/master/src/DependencyInjection/RunroomSamplesExtension.php#L43

I had to stop using it and return to the EasyExtendsBundle way. Why? Because I keep getting an error similar to this: https://stackoverflow.com/questions/44323315/symfony-compiler-pass-i-want-to-add-method-call-to-logger-service 

I think the problem is trying to use the compiler pass to add calls with objects without using definitions: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/src/Bridge/Symfony/DependencyInjection/Compiler/MapperCompilerPass.php#L41

That `$options` without this patch is an array containing an object, for some reason, Symfony does not like it.

I do not fully understand the problem, but I found this solution. I open the PR to discuss if it is the best approach or not. I know it is a BC break, but we should consider that actually this feature is imposible to use without an error. Of course, if the fix is accepted and test need fixing, I can do it.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix modifying entities (associations, discriminator columns and overrides) with DoctrineCollector
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
