### PR TITLE
Fix constraint for "doctrine/phpcr-odm"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "doctrine/common": "^2.7",
         "doctrine/orm": "^2.5",
-        "doctrine/phpcr-odm": "^1.4 || ^2.0",
+        "doctrine/phpcr-odm": "^1.4",
         "jackalope/jackalope-doctrine-dbal": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix constraint for "doctrine/phpcr-odm", removed unreachable range `^2.0` which has no available release.
See https://github.com/doctrine/phpcr-odm/releases.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->