### PR TITLE
Deprecate `Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle`

### DIFF
--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,6 +1,11 @@
 UPGRADE 1.x
 ===========
 
+### `Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle`
+
+Deprecated `Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle`. Use `Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle`
+instead.
+
 ### `Sonata\Doctrine\Types\JsonType` has been deprecated
 
 `doctrine/dbal` has a native implementation, `Doctrine\DBAL\Types\JsonType`, that
@@ -8,6 +13,6 @@ should be used instead.
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. 
-You can't extend them anymore, because they are only loaded when running internal tests. 
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).

--- a/src/Bridge/Symfony/SonataDoctrineBundle.php
+++ b/src/Bridge/Symfony/SonataDoctrineBundle.php
@@ -11,32 +11,18 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Sonata\Doctrine\Bridge\Symfony\Bundle;
+namespace Sonata\Doctrine\Bridge\Symfony;
 
 use Sonata\Doctrine\Bridge\Symfony\DependencyInjection\Compiler\AdapterCompilerPass;
 use Sonata\Doctrine\Bridge\Symfony\DependencyInjection\Compiler\MapperCompilerPass;
-use Sonata\Doctrine\Bridge\Symfony\DependencyInjection\SonataDoctrineExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @deprecated Since sonata-project/doctrine-extensions 1.x, to be removed in 2.0. Use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle instead.
- */
 final class SonataDoctrineBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new AdapterCompilerPass());
         $container->addCompilerPass(new MapperCompilerPass());
-    }
-
-    public function getPath()
-    {
-        return __DIR__.'/..';
-    }
-
-    protected function getContainerExtensionClass()
-    {
-        return SonataDoctrineExtension::class;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Deprecated `Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Triggered by sonata-project/SonataAdminBundle#6173.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle`.

### Deprecated
- Deprecated `Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle` in favor of `Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle`.
```