### PR TITLE
Add `SonataDoctrineSymfonyBundle` in order to be compatible with Symfony Flex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Sonata\\Doctrine\\": "src/"
+            "Sonata\\Doctrine\\": "src/",
+            "Sonata\\Doctrine\\Bridge\\Symfony\\": "src/Bridge/Symfony/"
         }
     },
     "autoload-dev": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,7 @@ parameters:
         - src
 
     excludes_analyse:
+        - src/Bridge/Symfony/Bundle/SonataDoctrineBundle.php
         - src/Test/EntityManagerMockFactory.php
         - tests/bootstrap.php
 

--- a/src/Bridge/Symfony/Bundle/SonataDoctrineBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataDoctrineBundle.php
@@ -13,30 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\Doctrine\Bridge\Symfony\Bundle;
 
-use Sonata\Doctrine\Bridge\Symfony\DependencyInjection\Compiler\AdapterCompilerPass;
-use Sonata\Doctrine\Bridge\Symfony\DependencyInjection\Compiler\MapperCompilerPass;
-use Sonata\Doctrine\Bridge\Symfony\DependencyInjection\SonataDoctrineExtension;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @deprecated Since sonata-project/doctrine-extensions 1.x, to be removed in 2.0. Use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle instead.
- */
-final class SonataDoctrineBundle extends Bundle
-{
-    public function build(ContainerBuilder $container)
-    {
-        $container->addCompilerPass(new AdapterCompilerPass());
-        $container->addCompilerPass(new MapperCompilerPass());
-    }
+@trigger_error(sprintf(
+    'The %s\SonataDoctrineBundle class is deprecated since sonata-project/doctrine-extensions 1.x, to be removed in version 2.0. Use %s instead.',
+    __NAMESPACE__,
+    SonataDoctrineBundle::class
+), E_USER_DEPRECATED);
 
-    public function getPath()
+if (false) {
+    /**
+     * NEXT_MAJOR: remove this class.
+     *
+     * @deprecated Since sonata-project/doctrine-extensions 1.x, to be removed in 2.0. Use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle instead.
+     */
+    final class SonataDoctrineBundle extends Bundle
     {
-        return __DIR__.'/..';
-    }
-
-    protected function getContainerExtensionClass()
-    {
-        return SonataDoctrineExtension::class;
     }
 }
+
+class_alias(SonataDoctrineBundle::class, __NAMESPACE__.'\SonataDoctrineBundle');

--- a/src/Bridge/Symfony/SonataDoctrineSymfonyBundle.php
+++ b/src/Bridge/Symfony/SonataDoctrineSymfonyBundle.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Doctrine\Bridge\Symfony;
+
+// This file and its class alias is required in order to let Symfony Flex
+// autodiscovery to find the bundle.
+// The string "Symfony\Component\HttpKernel\Bundle\Bundle" must also be present.
+// @see https://github.com/symfony/flex/pull/612/files.
+class_alias(SonataDoctrineBundle::class, __NAMESPACE__.'\SonataDoctrineSymfonyBundle');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add `SonataDoctrineSymfonyBundle` in order to be compatible with Symfony Flex.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\Exporter\Bridge\Symfony\SonataDoctrineSymfonyBundle` alias in order to fix Symfony Flex autodiscovery.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
