### PR TITLE
Fix conflict with class names

### DIFF
--- a/src/Bridge/Symfony/Bundle/SonataDoctrineBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataDoctrineBundle.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\Doctrine\Bridge\Symfony\Bundle;
 
-use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle;
+use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle as ForwardCompatibleSonataDoctrineBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 @trigger_error(sprintf(
     'The %s\SonataDoctrineBundle class is deprecated since sonata-project/doctrine-extensions 1.9, to be removed in version 2.0. Use %s instead.',
     __NAMESPACE__,
-    SonataDoctrineBundle::class
+    ForwardCompatibleSonataDoctrineBundle::class
 ), E_USER_DEPRECATED);
 
 if (false) {
@@ -33,4 +33,4 @@ if (false) {
     }
 }
 
-class_alias(SonataDoctrineBundle::class, __NAMESPACE__.'\SonataDoctrineBundle');
+class_alias(ForwardCompatibleSonataDoctrineBundle::class, __NAMESPACE__.'\SonataDoctrineBundle');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There is a conflict with the class names, I couldn't come up with a better name 😬

Ref: https://github.com/sonata-project/SonataAdminBundle/pull/6264

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed conflict with class names.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
