### PR TITLE
Fix #218

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPass.php
@@ -36,10 +36,12 @@ final class AdapterCompilerPass implements CompilerPassInterface
             $container->removeDefinition('sonata.doctrine.adapter.doctrine_orm');
         }
 
-        if ($container->has('doctrine_phpcr')) {
-            $definition->addMethodCall('addAdapter', [new Reference('sonata.doctrine.adapter.doctrine_phpcr')]);
-        } else {
-            $container->removeDefinition('sonata.doctrine.adapter.doctrine_phpcr');
+        if ($container->has('sonata.doctrine.adapter.doctrine_phpcr')) {
+            if ($container->has('doctrine_phpcr')) {
+                $definition->addMethodCall('addAdapter', [new Reference('sonata.doctrine.adapter.doctrine_phpcr')]);
+            } else {
+                $container->removeDefinition('sonata.doctrine.adapter.doctrine_phpcr');
+            }
         }
     }
 

--- a/src/Bridge/Symfony/DependencyInjection/SonataDoctrineExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/SonataDoctrineExtension.php
@@ -35,7 +35,8 @@ class SonataDoctrineExtension extends Extension
             $loader->load('mapper_orm.php');
         }
 
-        if (class_exists(DocumentManager::class)) {
+        $bundles = $container->getParameter('kernel.bundles');
+        if (class_exists(DocumentManager::class) && isset($bundles['DoctrinePHPCRBundle'])) {
             $loader->load('doctrine_phpcr.php');
         }
     }


### PR DESCRIPTION
### Fixed #218 
Check adapter exists before adding.

```php
if ($container->has('sonata.doctrine.adapter.doctrine_phpcr')) {
    $definition->addMethodCall('addAdapter', [new Reference('sonata.doctrine.adapter.doctrine_phpcr')]);
}