### PR TITLE
Add conflict with doctrine/mongodb-odm <2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,13 @@
         "doctrine/dbal": "^2.6",
         "doctrine/persistence": "^1.3.6 || ^2.0"
     },
+    "conflict": {
+        "doctrine/mongodb-odm": "<2.0"
+    },
     "require-dev": {
         "doctrine/common": "^2.7 || ^3.0",
         "doctrine/doctrine-bundle": "^2.0",
-        "doctrine/mongodb-odm": "^2.1",
+        "doctrine/mongodb-odm": "^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/phpcr-odm": "^1.5.2",
         "jackalope/jackalope-doctrine-dbal": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,10 @@
         "doctrine/persistence": "^1.3.6 || ^2.0"
     },
     "conflict": {
-        "doctrine/mongodb-odm": "<2.0"
+        "doctrine/doctrine-bundle": "<2.0",
+        "doctrine/mongodb-odm": "<2.0",
+        "doctrine/orm": "<2.5",
+        "doctrine/phpcr-odm": "<1.5.2"
     },
     "require-dev": {
         "doctrine/common": "^2.7 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/dev-kit/issues/1069

We are dropping support for doctrine/mongodb-odm <2.0, this allows us to not install `alcaeus/mongo-php-adapter` in GA for tests.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove support for `doctrine/mongodb-odm` <2.0
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
