### PR TITLE
Remove createMock abstract method

### DIFF
--- a/src/Test/EntityManagerMockFactoryTrait.php
+++ b/src/Test/EntityManagerMockFactoryTrait.php
@@ -59,6 +59,4 @@ trait EntityManagerMockFactoryTrait
 
         return $em;
     }
-
-    abstract protected function createMock($originalClassName): MockObject;
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Compatibility with PHPUnit 9 
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

It makes no sense to have this abstract method.