### PR TITLE
Bump static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,13 +75,5 @@
         "psr-4": {
             "Sonata\\Doctrine\\Tests\\": "tests/"
         }
-    },
-    "scripts": {
-        "post-install-cmd": [
-            "[ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/simple-phpunit install"
-        ],
-        "post-update-cmd": [
-            "[ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/simple-phpunit install"
-        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,12 @@
         "jackalope/jackalope-doctrine-dbal": "^1.0",
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
+        "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12.54",
+        "phpstan/phpstan-phpunit": "^0.12.16",
+        "phpstan/phpstan-strict-rules": "^0.12.10",
         "phpunit/phpunit": "^9.5",
+        "psalm/plugin-phpunit": "^0.16",
         "symfony/dependency-injection": "^4.4 || ^5.1",
         "symfony/expression-language": "^4.4 || ^5.1",
         "symfony/framework-bundle": "^4.4 || ^5.1",
@@ -71,5 +75,13 @@
         "psr-4": {
             "Sonata\\Doctrine\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "post-install-cmd": [
+            "[ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/simple-phpunit install"
+        ],
+        "post-update-cmd": [
+            "[ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/simple-phpunit install"
+        ]
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,27 +1,11 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Strict comparison using \\=\\=\\= between null and object will always evaluate to false\\.$#"
-			count: 1
-			path: src/Adapter/ORM/DoctrineORMAdapter.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between null and object will always evaluate to false\\.$#"
-			count: 1
-			path: src/Adapter/PHPCR/DoctrinePHPCRAdapter.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getConnection\\(\\)\\.$#"
-			count: 1
-			path: src/Document/BaseDocumentManager.php
-
-		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata<T of object>\\:\\:\\$table\\.$#"
-			count: 1
-			path: src/Model/BaseManager.php
-
-		-
+		- # The class is deprecated and will be removed in NEXT_MAJOR
 			message: "#^Return typehint of method Sonata\\\\Doctrine\\\\Model\\\\PageableManagerInterface\\:\\:getPager\\(\\) has invalid type Sonata\\\\DatagridBundle\\\\Pager\\\\PagerInterface\\.$#"
 			count: 1
 			path: src/Model/PageableManagerInterface.php
 
+		- # The class is deprecated and will be removed in NEXT_MAJOR
+			message: "#^Call to protected method createMock\\(\\) of class PHPUnit\\\\Framework\\\\TestCase\\.$#"
+			count: 5
+			path: src/Test/EntityManagerMockFactory.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,8 +3,6 @@ includes:
 
 parameters:
     level: max
-    bootstrapFiles:
-        - vendor/bin/.phpunit/phpunit/vendor/autoload.php
     paths:
         - src
         - tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,13 +2,14 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 5
-
+    level: max
+    bootstrapFiles:
+        - vendor/bin/.phpunit/phpunit/vendor/autoload.php
     paths:
         - src
-
-    excludes_analyse:
-        - src/Bridge/Symfony/Bundle/SonataDoctrineBundle.php
-        - src/Test/EntityManagerMockFactory.php
-        - tests/bootstrap.php
-
+        - tests
+    treatPhpDocTypesAsCertain: false
+    checkGenericClassInNonGenericObjectType: true
+    checkMissingIterableValueType: true
+    checkMissingVarTagTypehint: true
+    checkMissingTypehints: true

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,6 +5,11 @@
             <code>\Sonata\CoreBundle\Model\Adapter\AdapterInterface</code>
         </UndefinedClass>
     </file>
+    <file src="src/Bridge/Symfony/Bundle/SonataDoctrineBundle.php">
+        <TypeDoesNotContainType occurrences="1">
+            <code>false</code>
+        </TypeDoesNotContainType>
+    </file>
     <file src="src/Model/ManagerInterface.php">
         <UndefinedClass occurrences="1">
             <code>\Sonata\CoreBundle\Model\ManagerInterface</code>
@@ -19,8 +24,8 @@
         </UndefinedDocblockClass>
     </file>
     <file src="src/Test/EntityManagerMockFactory.php">
-        <UndefinedClass occurrences="1">
-            <code>TestCase</code>
-        </UndefinedClass>
+        <InaccessibleMethod occurrences="5">
+            <code>createMock</code>
+        </InaccessibleMethod>
     </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,20 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.17.2@9e526d9cb569fe4631e6a737bbb7948d05596e3f">
+    <!-- NEXT_MAJOR: Remove the CoreBundle support -->
     <file src="src/Adapter/AdapterInterface.php">
         <UndefinedClass occurrences="1">
             <code>\Sonata\CoreBundle\Model\Adapter\AdapterInterface</code>
         </UndefinedClass>
     </file>
+    <!-- NEXT_MAJOR: Remove the CoreBundle support -->
     <file src="src/Bridge/Symfony/Bundle/SonataDoctrineBundle.php">
         <TypeDoesNotContainType occurrences="1">
             <code>false</code>
         </TypeDoesNotContainType>
     </file>
+    <!-- NEXT_MAJOR: Remove the CoreBundle support -->
     <file src="src/Model/ManagerInterface.php">
         <UndefinedClass occurrences="1">
             <code>\Sonata\CoreBundle\Model\ManagerInterface</code>
         </UndefinedClass>
     </file>
+    <!-- NEXT_MAJOR: Remove the CoreBundle support -->
     <file src="src/Model/PageableManagerInterface.php">
         <UndefinedClass occurrences="1">
             <code>\Sonata\CoreBundle\Model\PageableManagerInterface</code>
@@ -22,10 +26,5 @@
         <UndefinedDocblockClass occurrences="1">
             <code>PagerInterface</code>
         </UndefinedDocblockClass>
-    </file>
-    <file src="src/Test/EntityManagerMockFactory.php">
-        <InaccessibleMethod occurrences="5">
-            <code>createMock</code>
-        </InaccessibleMethod>
     </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" errorLevel="7" resolveFromConfigFile="true" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd" errorBaseline="psalm-baseline.xml">
+<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" errorLevel="3" resolveFromConfigFile="true" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd" autoloader="vendor/bin/.phpunit/phpunit/vendor/autoload.php" errorBaseline="psalm-baseline.xml">
     <projectFiles>
         <directory name="src"/>
+        <directory name="tests"/>
         <ignoreFiles>
             <!-- Deprecated class with strange usage of createMock function -->
             <file name="src/Test/EntityManagerMockFactory.php"/>
             <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" errorLevel="3" resolveFromConfigFile="true" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd" autoloader="vendor/bin/.phpunit/phpunit/vendor/autoload.php" errorBaseline="psalm-baseline.xml">
+<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" errorLevel="3" resolveFromConfigFile="true" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd" errorBaseline="psalm-baseline.xml">
     <projectFiles>
         <directory name="src"/>
         <directory name="tests"/>

--- a/src/Adapter/AdapterChain.php
+++ b/src/Adapter/AdapterChain.php
@@ -20,6 +20,9 @@ class AdapterChain implements AdapterInterface
      */
     protected $adapters = [];
 
+    /**
+     * @return void
+     */
     public function addAdapter(AdapterInterface $adapter)
     {
         $this->adapters[] = $adapter;
@@ -30,7 +33,7 @@ class AdapterChain implements AdapterInterface
         foreach ($this->adapters as $adapter) {
             $identifier = $adapter->getNormalizedIdentifier($model);
 
-            if ($identifier) {
+            if (null !== $identifier) {
                 return $identifier;
             }
         }
@@ -43,7 +46,7 @@ class AdapterChain implements AdapterInterface
         foreach ($this->adapters as $adapter) {
             $safeIdentifier = $adapter->getUrlSafeIdentifier($model);
 
-            if ($safeIdentifier) {
+            if (null !== $safeIdentifier) {
                 return $safeIdentifier;
             }
         }

--- a/src/Adapter/ORM/DoctrineORMAdapter.php
+++ b/src/Adapter/ORM/DoctrineORMAdapter.php
@@ -34,12 +34,19 @@ class DoctrineORMAdapter implements AdapterInterface
 
     public function getNormalizedIdentifier($model)
     {
-        if (null === $model) {
-            return null;
-        }
-
+        // NEXT_MAJOR: Remove this check and add type hint instead.
         if (!\is_object($model)) {
-            throw new \RuntimeException('Invalid argument, object or null required');
+            if (null === $model) {
+                @trigger_error(sprintf(
+                    'Passing other type than object as argument 1 for method %s() is deprecated since'
+                    .' sonata-project/doctrine-extensions 1.x. It will accept only object in version 2.0.',
+                    __METHOD__
+                ), \E_USER_DEPRECATED);
+
+                return null;
+            }
+
+            throw new \RuntimeException('Invalid argument, object required');
         }
 
         $manager = $this->registry->getManagerForClass(\get_class($model));

--- a/src/Adapter/ORM/DoctrineORMAdapter.php
+++ b/src/Adapter/ORM/DoctrineORMAdapter.php
@@ -46,7 +46,11 @@ class DoctrineORMAdapter implements AdapterInterface
                 return null;
             }
 
-            throw new \RuntimeException('Invalid argument, object required');
+            throw new \RuntimeException(sprintf(
+                'Argument 1 passed to "%s()" must be an object, %s given.',
+                __METHOD__,
+                \gettype($model)
+            ));
         }
 
         $manager = $this->registry->getManagerForClass(\get_class($model));

--- a/src/Adapter/PHPCR/DoctrinePHPCRAdapter.php
+++ b/src/Adapter/PHPCR/DoctrinePHPCRAdapter.php
@@ -47,7 +47,11 @@ class DoctrinePHPCRAdapter implements AdapterInterface
                 return null;
             }
 
-            throw new \RuntimeException('Invalid argument, object required');
+            throw new \RuntimeException(sprintf(
+                'Argument 1 passed to "%s()" must be an object, %s given.',
+                __METHOD__,
+                \gettype($model)
+            ));
         }
 
         $manager = $this->registry->getManagerForClass(\get_class($model));

--- a/src/Adapter/PHPCR/DoctrinePHPCRAdapter.php
+++ b/src/Adapter/PHPCR/DoctrinePHPCRAdapter.php
@@ -35,12 +35,19 @@ class DoctrinePHPCRAdapter implements AdapterInterface
 
     public function getNormalizedIdentifier($model)
     {
-        if (null === $model) {
-            return null;
-        }
-
+        // NEXT_MAJOR: Remove this check and add type hint instead.
         if (!\is_object($model)) {
-            throw new \RuntimeException('Invalid argument, object or null required');
+            if (null === $model) {
+                @trigger_error(sprintf(
+                    'Passing other type than object as argument 1 for method %s() is deprecated since'
+                    .' sonata-project/doctrine-extensions 1.x. It will accept only object in version 2.0.',
+                    __METHOD__
+                ), \E_USER_DEPRECATED);
+
+                return null;
+            }
+
+            throw new \RuntimeException('Invalid argument, object required');
         }
 
         $manager = $this->registry->getManagerForClass(\get_class($model));

--- a/src/Bridge/Symfony/Bundle/SonataDoctrineBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataDoctrineBundle.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
     ForwardCompatibleSonataDoctrineBundle::class
 ), \E_USER_DEPRECATED);
 
+// @phpstan-ignore-next-line
 if (false) {
     /**
      * NEXT_MAJOR: remove this class.

--- a/src/Bridge/Symfony/DependencyInjection/SonataDoctrineExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/SonataDoctrineExtension.php
@@ -25,6 +25,11 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 class SonataDoctrineExtension extends Extension
 {
+    /**
+     * @param mixed[] $configs
+     *
+     * @return void
+     */
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
@@ -36,6 +41,8 @@ class SonataDoctrineExtension extends Extension
         }
 
         $bundles = $container->getParameter('kernel.bundles');
+        \assert(\is_array($bundles));
+
         if (class_exists(DocumentManager::class) && isset($bundles['DoctrinePHPCRBundle'])) {
             $loader->load('doctrine_phpcr.php');
         }

--- a/src/Bridge/Symfony/SonataDoctrineBundle.php
+++ b/src/Bridge/Symfony/SonataDoctrineBundle.php
@@ -20,6 +20,9 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class SonataDoctrineBundle extends Bundle
 {
+    /**
+     * @return void
+     */
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new AdapterCompilerPass());

--- a/src/Document/BaseDocumentManager.php
+++ b/src/Document/BaseDocumentManager.php
@@ -37,7 +37,7 @@ abstract class BaseDocumentManager extends BaseManager
     {
         if ('dm' === $name) {
             @trigger_error(
-                'Accessing to the entity manager with the magic getter is deprecated since'
+                'Accessing to the document manager through the magic getter is deprecated since'
                 .' sonata-project/sonata-doctrine-extensions 1.x and will throw an exception in 2.0.'
                 .' Use the "getObjectManager()" method instead.',
                 \E_USER_DEPRECATED

--- a/src/Document/BaseDocumentManager.php
+++ b/src/Document/BaseDocumentManager.php
@@ -27,20 +27,36 @@ abstract class BaseDocumentManager extends BaseManager
     /**
      * Make sure the code is compatible with legacy code.
      *
+     * NEXT_MAJOR: Remove the magic getter.
+     *
+     * @param string $name
+     *
      * @return mixed
      */
     public function __get($name)
     {
         if ('dm' === $name) {
+            @trigger_error(
+                'Accessing to the entity manager with the magic getter is deprecated since'
+                .' sonata-project/sonata-doctrine-extensions 1.x and will throw an exception in 2.0.'
+                .' Use the "getObjectManager()" method instead.',
+                \E_USER_DEPRECATED
+            );
+
             return $this->getObjectManager();
         }
 
         throw new \RuntimeException(sprintf('The property %s does not exists', $name));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/sonata-doctrine-extensions 1.x
+     */
     public function getConnection()
     {
-        return $this->getObjectManager()->getConnection();
+        throw new \LogicException('MongoDB does not use a database connection.');
     }
 
     /**

--- a/src/Document/BasePHPCRManager.php
+++ b/src/Document/BasePHPCRManager.php
@@ -35,7 +35,7 @@ abstract class BasePHPCRManager extends BaseManager
     {
         if ('dm' === $name) {
             @trigger_error(
-                'Accessing to the entity manager with the magic getter is deprecated since'
+                'Accessing to the document manager through the magic getter is deprecated since'
                 .' sonata-project/sonata-doctrine-extensions 1.x and will throw an exception in 2.0.'
                 .' Use the "getObjectManager()" method instead.',
                 \E_USER_DEPRECATED

--- a/src/Document/BasePHPCRManager.php
+++ b/src/Document/BasePHPCRManager.php
@@ -25,11 +25,22 @@ abstract class BasePHPCRManager extends BaseManager
     /**
      * Make sure the code is compatible with legacy code.
      *
+     * NEXT_MAJOR: Remove the magic getter.
+     *
+     * @param string $name
+     *
      * @return mixed
      */
     public function __get($name)
     {
         if ('dm' === $name) {
+            @trigger_error(
+                'Accessing to the entity manager with the magic getter is deprecated since'
+                .' sonata-project/sonata-doctrine-extensions 1.x and will throw an exception in 2.0.'
+                .' Use the "getObjectManager()" method instead.',
+                \E_USER_DEPRECATED
+            );
+
             return $this->getObjectManager();
         }
 
@@ -37,9 +48,9 @@ abstract class BasePHPCRManager extends BaseManager
     }
 
     /**
-     * {@inheritdoc}
+     * NEXT_MAJOR: Remove this method.
      *
-     * @throws \LogicException Each call
+     * @deprecated since sonata-project/sonata-doctrine-extensions 1.x
      */
     public function getConnection()
     {
@@ -47,9 +58,9 @@ abstract class BasePHPCRManager extends BaseManager
     }
 
     /**
-     * {@inheritdoc}
+     * NEXT_MAJOR: Remove this method.
      *
-     * @throws \LogicException Each call
+     * @deprecated since sonata-project/sonata-doctrine-extensions 1.x
      */
     public function getTableName()
     {

--- a/src/Entity/BaseEntityManager.php
+++ b/src/Entity/BaseEntityManager.php
@@ -38,7 +38,7 @@ abstract class BaseEntityManager extends BaseManager
     {
         if ('em' === $name) {
             @trigger_error(
-                'Accessing to the entity manager with the magic getter is deprecated since'
+                'Accessing to the entity manager through the magic getter is deprecated since'
                 .' sonata-project/sonata-doctrine-extensions 1.x and will throw an exception in 2.0.'
                 .' Use the "getObjectManager()" method instead.',
                 \E_USER_DEPRECATED

--- a/src/Entity/BaseEntityManager.php
+++ b/src/Entity/BaseEntityManager.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Doctrine\Entity;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Sonata\Doctrine\Model\BaseManager;
 
@@ -28,41 +28,62 @@ abstract class BaseEntityManager extends BaseManager
     /**
      * Make sure the code is compatible with legacy code.
      *
+     * NEXT_MAJOR: Remove the magic getter.
+     *
+     * @param string $name
+     *
      * @return mixed
      */
     public function __get($name)
     {
         if ('em' === $name) {
+            @trigger_error(
+                'Accessing to the entity manager with the magic getter is deprecated since'
+                .' sonata-project/sonata-doctrine-extensions 1.x and will throw an exception in 2.0.'
+                .' Use the "getObjectManager()" method instead.',
+                \E_USER_DEPRECATED
+            );
+
             return $this->getObjectManager();
         }
 
         throw new \RuntimeException(sprintf('The property %s does not exists', $name));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/sonata-doctrine-extensions 1.x
+     */
     public function getConnection()
     {
+        @trigger_error(sprintf(
+            'The "%s()" method is deprecated since sonata-project/sonata-doctrine-extensions 1.x'
+            .' and will be removed in version 2.0. Use "%s" instead.',
+            __METHOD__,
+            'getEntityManager()->getConnection()'
+        ), \E_USER_DEPRECATED);
+
         return $this->getEntityManager()->getConnection();
     }
 
     /**
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {
         $objectManager = $this->getObjectManager();
-
-        \assert($objectManager instanceof EntityManager);
+        \assert($objectManager instanceof EntityManagerInterface);
 
         return $objectManager;
     }
 
+    /**
+     * @phpstan-return EntityRepository<T>
+     */
     protected function getRepository(): EntityRepository
     {
-        $repository = $this->getEntityManager()->getRepository($this->class);
-
-        \assert($repository instanceof EntityRepository);
-
-        return $repository;
+        return $this->getEntityManager()->getRepository($this->class);
     }
 }
 

--- a/src/Mapper/Builder/ColumnDefinitionBuilder.php
+++ b/src/Mapper/Builder/ColumnDefinitionBuilder.php
@@ -29,6 +29,11 @@ final class ColumnDefinitionBuilder
         return new self();
     }
 
+    /**
+     * @param mixed $value
+     *
+     * @return $this
+     */
     public function add(string $key, $value): self
     {
         $this->options[$key] = $value;
@@ -36,6 +41,9 @@ final class ColumnDefinitionBuilder
         return $this;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getOptions(): array
     {
         return $this->options;

--- a/src/Mapper/Builder/OptionsBuilder.php
+++ b/src/Mapper/Builder/OptionsBuilder.php
@@ -56,6 +56,11 @@ final class OptionsBuilder
         return new self();
     }
 
+    /**
+     * @param mixed $value
+     *
+     * @return $this
+     */
     public function add(string $key, $value): self
     {
         $this->options[$key] = $value;
@@ -83,6 +88,9 @@ final class OptionsBuilder
         return new self(self::MANY_TO_MANY, $fieldName, $targetEntity);
     }
 
+    /**
+     * @return $this
+     */
     public function mappedBy(string $mappedBy): self
     {
         if (!\in_array($this->type, [self::ONE_TO_MANY, self::ONE_TO_ONE, self::MANY_TO_MANY], true)) {
@@ -96,6 +104,9 @@ final class OptionsBuilder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function inversedBy(string $inversedBy): self
     {
         if (!\in_array($this->type, [self::ONE_TO_ONE, self::MANY_TO_ONE, self::MANY_TO_MANY], true)) {
@@ -144,6 +155,8 @@ final class OptionsBuilder
 
     /**
      * @param 'ASC'|'DESC' $orientation
+     *
+     * @return $this
      */
     public function addOrder(string $field, string $orientation): self
     {
@@ -171,6 +184,8 @@ final class OptionsBuilder
      *     onDelete?: string,
      *     columnDefinition?: string
      * } $joinColumn
+     *
+     * @return $this
      */
     public function addJoin(array $joinColumn): self
     {
@@ -190,6 +205,8 @@ final class OptionsBuilder
     }
 
     /**
+     * @return $this
+     *
      * @psalm-param list<'persist'|'remove'|'merge'|'detach'|'refresh'|'all'> $value
      */
     public function cascade(array $value): self
@@ -199,6 +216,9 @@ final class OptionsBuilder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function orphanRemoval(): self
     {
         if (!\in_array($this->type, [self::ONE_TO_ONE, self::ONE_TO_MANY], true)) {
@@ -212,6 +232,9 @@ final class OptionsBuilder
         return $this;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getOptions(): array
     {
         return $this->options;

--- a/src/Mapper/DoctrineCollector.php
+++ b/src/Mapper/DoctrineCollector.php
@@ -19,37 +19,37 @@ use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
 final class DoctrineCollector
 {
     /**
-     * @var array
+     * @var array<class-string, array<string, array<string, mixed>>>
      */
     private $associations = [];
 
     /**
-     * @var array
+     * @var array<class-string, array<string, array<string>>>
      */
     private $indexes = [];
 
     /**
-     * @var array
+     * @var array<class-string, array<string, array<string>>>
      */
     private $uniques = [];
 
     /**
-     * @var array
+     * @var array<class-string, array<string, class-string>>
      */
     private $discriminators = [];
 
     /**
-     * @var array
+     * @var array<class-string, array<string, mixed>>
      */
     private $discriminatorColumns = [];
 
     /**
-     * @var array
+     * @var array<class-string, int>
      */
     private $inheritanceTypes = [];
 
     /**
-     * @var array
+     * @var array<class-string, array<string, array<string, mixed>>>
      */
     private $overrides = [];
 
@@ -77,8 +77,10 @@ final class DoctrineCollector
     /**
      * Add a discriminator to a class.
      *
-     * @param string $key                Key is the database value and values are the classes
-     * @param string $discriminatorClass The mapped class
+     * @param string $key Key is the database value and values are the classes
+     *
+     * @phpstan-param class-string $class
+     * @phpstan-param class-string $discriminatorClass
      */
     public function addDiscriminator(string $class, string $key, string $discriminatorClass): void
     {
@@ -91,6 +93,9 @@ final class DoctrineCollector
         }
     }
 
+    /**
+     * @phpstan-param class-string $class
+     */
     public function addDiscriminatorColumn(string $class, ColumnDefinitionBuilder $columnDef): void
     {
         if (!isset($this->discriminatorColumns[$class])) {
@@ -100,6 +105,8 @@ final class DoctrineCollector
 
     /**
      * @param int $type
+     *
+     * @phpstan-param class-string $class
      */
     public function addInheritanceType(string $class, $type): void
     {
@@ -116,6 +123,9 @@ final class DoctrineCollector
         }
     }
 
+    /**
+     * @phpstan-param class-string $class
+     */
     public function addAssociation(string $class, string $type, OptionsBuilder $options): void
     {
         if (!isset($this->associations[$class])) {
@@ -130,7 +140,9 @@ final class DoctrineCollector
     }
 
     /**
-     * @param array<string> $columns
+     * @param string[] $columns
+     *
+     * @phpstan-param class-string $class
      */
     public function addIndex(string $class, string $name, array $columns): void
     {
@@ -148,7 +160,9 @@ final class DoctrineCollector
     }
 
     /**
-     * @param array<string> $columns
+     * @param string[] $columns
+     *
+     * @phpstan-param class-string $class
      */
     public function addUnique(string $class, string $name, array $columns): void
     {
@@ -165,6 +179,9 @@ final class DoctrineCollector
         $this->uniques[$class][$name] = $columns;
     }
 
+    /**
+     * @phpstan-param class-string $class
+     */
     public function addOverride(string $class, string $type, OptionsBuilder $options): void
     {
         if (!isset($this->overrides[$class])) {
@@ -178,36 +195,57 @@ final class DoctrineCollector
         $this->overrides[$class][$type][] = $options->getOptions();
     }
 
+    /**
+     * @return array<class-string, array<string, array<string, mixed>>>
+     */
     public function getAssociations(): array
     {
         return $this->associations;
     }
 
+    /**
+     * @return array<class-string, array<string, class-string>>
+     */
     public function getDiscriminators(): array
     {
         return $this->discriminators;
     }
 
+    /**
+     * @return array<class-string, array<string, mixed>>
+     */
     public function getDiscriminatorColumns(): array
     {
         return $this->discriminatorColumns;
     }
 
+    /**
+     * @return array<class-string, int>
+     */
     public function getInheritanceTypes(): array
     {
         return $this->inheritanceTypes;
     }
 
+    /**
+     * @return array<class-string, array<string, array<string>>>
+     */
     public function getIndexes(): array
     {
         return $this->indexes;
     }
 
+    /**
+     * @return array<class-string, array<string, array<string>>>
+     */
     public function getUniques(): array
     {
         return $this->uniques;
     }
 
+    /**
+     * @return array<class-string, array<string, array<string, mixed>>>
+     */
     public function getOverrides(): array
     {
         return $this->overrides;
@@ -224,6 +262,9 @@ final class DoctrineCollector
         $this->overrides = [];
     }
 
+    /**
+     * @param string[] $columns
+     */
     private function verifyColumnNames(array $columns): void
     {
         foreach ($columns as $column) {

--- a/src/Mapper/DoctrineCollector.php
+++ b/src/Mapper/DoctrineCollector.php
@@ -19,7 +19,7 @@ use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
 final class DoctrineCollector
 {
     /**
-     * @var array<class-string, array<string, array<string, mixed>>>
+     * @var array<class-string, array<string, array<array<string, mixed>>>>
      */
     private $associations = [];
 
@@ -49,7 +49,7 @@ final class DoctrineCollector
     private $inheritanceTypes = [];
 
     /**
-     * @var array<class-string, array<string, array<string, mixed>>>
+     * @var array<class-string, array<string, array<array<string, mixed>>>>
      */
     private $overrides = [];
 
@@ -196,7 +196,7 @@ final class DoctrineCollector
     }
 
     /**
-     * @return array<class-string, array<string, array<string, mixed>>>
+     * @return array<class-string, array<string, array<array<string, mixed>>>>
      */
     public function getAssociations(): array
     {
@@ -244,7 +244,7 @@ final class DoctrineCollector
     }
 
     /**
-     * @return array<class-string, array<string, array<string, mixed>>>
+     * @return array<class-string, array<string, array<array<string, mixed>>>>
      */
     public function getOverrides(): array
     {

--- a/src/Mapper/ORM/DoctrineORMMapper.php
+++ b/src/Mapper/ORM/DoctrineORMMapper.php
@@ -21,7 +21,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 final class DoctrineORMMapper implements EventSubscriber
 {
     /**
-     * @var array<class-string, array<string, array<string, mixed>>>
+     * @var array<class-string, array<string, array<array<string, mixed>>>>
      */
     private $associations = [];
 
@@ -51,7 +51,7 @@ final class DoctrineORMMapper implements EventSubscriber
     private $uniques = [];
 
     /**
-     * @var array<class-string, array<string, array<string, mixed>>>
+     * @var array<class-string, array<string, array<array<string, mixed>>>>
      */
     private $overrides = [];
 
@@ -63,7 +63,7 @@ final class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
-     * @param array<string, mixed> $options
+     * @param array<array<string, mixed>> $options
      *
      * @phpstan-param class-string $class
      */
@@ -176,7 +176,7 @@ final class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
-     * @param array<string, mixed> $options
+     * @param array<array<string, mixed>> $options
      *
      * @phpstan-param class-string $class
      */

--- a/src/Mapper/ORM/DoctrineORMMapper.php
+++ b/src/Mapper/ORM/DoctrineORMMapper.php
@@ -21,37 +21,37 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 final class DoctrineORMMapper implements EventSubscriber
 {
     /**
-     * @var array
+     * @var array<class-string, array<string, array<string, mixed>>>
      */
     private $associations = [];
 
     /**
-     * @var array
+     * @var array<class-string, array<string, class-string>>
      */
     private $discriminators = [];
 
     /**
-     * @var array
+     * @var array<class-string, array<string, mixed>>
      */
     private $discriminatorColumns = [];
 
     /**
-     * @var array
+     * @var array<class-string, int>
      */
     private $inheritanceTypes = [];
 
     /**
-     * @var array
+     * @var array<class-string, array<string, array<string>>>
      */
     private $indexes = [];
 
     /**
-     * @var array
+     * @var array<class-string, array<string, array<string>>>
      */
     private $uniques = [];
 
     /**
-     * @var array
+     * @var array<class-string, array<string, array<string, mixed>>>
      */
     private $overrides = [];
 
@@ -63,7 +63,9 @@ final class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
-     * @param array $options
+     * @param array<string, mixed> $options
+     *
+     * @phpstan-param class-string $class
      */
     public function addAssociation(string $class, string $type, $options): void
     {
@@ -85,8 +87,10 @@ final class DoctrineORMMapper implements EventSubscriber
     /**
      * Add a discriminator to a class.
      *
-     * @param string $key                Key is the database value and values are the classes
-     * @param string $discriminatorClass The mapped class
+     * @param string $key Key is the database value and values are the classes
+     *
+     * @phpstan-param class-string $class
+     * @phpstan-param class-string $discriminatorClass
      */
     public function addDiscriminator(string $class, string $key, string $discriminatorClass): void
     {
@@ -100,7 +104,9 @@ final class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
-     * @param array $columnDef
+     * @param array<string, mixed> $columnDef
+     *
+     * @phpstan-param class-string $class
      */
     public function addDiscriminatorColumn(string $class, $columnDef): void
     {
@@ -118,6 +124,8 @@ final class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
+     * @phpstan-param class-string $class
+     *
      * @see ClassMetadata for supported types
      */
     public function addInheritanceType(string $class, int $type): void
@@ -128,7 +136,9 @@ final class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
-     * @param array<string> $columns
+     * @param string[] $columns
+     *
+     * @phpstan-param class-string $class
      */
     public function addIndex(string $class, string $name, array $columns): void
     {
@@ -146,7 +156,9 @@ final class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
-     * @param array<string> $columns
+     * @param string[] $columns
+     *
+     * @phpstan-param class-string $class
      */
     public function addUnique(string $class, string $name, array $columns): void
     {
@@ -164,7 +176,9 @@ final class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
-     * @param array $options
+     * @param array<string, mixed> $options
+     *
+     * @phpstan-param class-string $class
      */
     public function addOverride(string $class, string $type, $options): void
     {
@@ -198,6 +212,8 @@ final class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
+     * @param ClassMetadata<object> $metadata
+     *
      * @throws \RuntimeException
      */
     private function loadAssociations(ClassMetadata $metadata): void
@@ -214,6 +230,7 @@ final class DoctrineORMMapper implements EventSubscriber
                         continue;
                     }
 
+                    // @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/1105
                     \call_user_func([$metadata, $type], $mapping);
                 }
             }
@@ -223,6 +240,8 @@ final class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
+     * @param ClassMetadata<object> $metadata
+     *
      * @throws \RuntimeException
      */
     private function loadDiscriminatorColumns(ClassMetadata $metadata): void
@@ -247,6 +266,8 @@ final class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
+     * @param ClassMetadata<object> $metadata
+     *
      * @throws \RuntimeException
      */
     private function loadInheritanceTypes(ClassMetadata $metadata): void
@@ -267,6 +288,8 @@ final class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
+     * @param ClassMetadata<object> $metadata
+     *
      * @throws \RuntimeException
      */
     private function loadDiscriminators(ClassMetadata $metadata): void
@@ -289,6 +312,9 @@ final class DoctrineORMMapper implements EventSubscriber
         }
     }
 
+    /**
+     * @param ClassMetadata<object> $metadata
+     */
     private function loadIndexes(ClassMetadata $metadata): void
     {
         if (!\array_key_exists($metadata->getName(), $this->indexes)) {
@@ -302,6 +328,9 @@ final class DoctrineORMMapper implements EventSubscriber
         }
     }
 
+    /**
+     * @param ClassMetadata<object> $metadata
+     */
     private function loadUniques(ClassMetadata $metadata): void
     {
         if (!\array_key_exists($metadata->getName(), $this->uniques)) {
@@ -315,6 +344,9 @@ final class DoctrineORMMapper implements EventSubscriber
         }
     }
 
+    /**
+     * @param ClassMetadata<object> $metadata
+     */
     private function loadOverrides(ClassMetadata $metadata): void
     {
         if (!\array_key_exists($metadata->getName(), $this->overrides)) {
@@ -324,6 +356,7 @@ final class DoctrineORMMapper implements EventSubscriber
         try {
             foreach ($this->overrides[$metadata->getName()] as $type => $overrides) {
                 foreach ($overrides as $override) {
+                    // @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/1105
                     \call_user_func([$metadata, $type], $override['fieldName'], $override);
                 }
             }
@@ -336,6 +369,9 @@ final class DoctrineORMMapper implements EventSubscriber
         }
     }
 
+    /**
+     * @param string[] $columns
+     */
     private function verifyColumnNames(array $columns): void
     {
         foreach ($columns as $column) {

--- a/src/Model/BaseManager.php
+++ b/src/Model/BaseManager.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Doctrine\Model;
 
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
@@ -57,7 +58,7 @@ abstract class BaseManager implements ManagerInterface, ClearableManagerInterfac
     {
         $manager = $this->registry->getManagerForClass($this->class);
 
-        if (!$manager) {
+        if (null === $manager) {
             throw new \RuntimeException(sprintf(
                 'Unable to find the mapping information for the class %s.'
                 .' Please check the `auto_mapping` option'
@@ -129,9 +130,23 @@ abstract class BaseManager implements ManagerInterface, ClearableManagerInterfac
         }
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/sonata-doctrine-extensions 1.x
+     */
     public function getTableName()
     {
-        return $this->getObjectManager()->getClassMetadata($this->class)->table['name'];
+        @trigger_error(sprintf(
+            'The "%s()" method is deprecated since sonata-project/sonata-doctrine-extensions 1.x'
+            .' and will be removed in version 2.0.',
+            __METHOD__
+        ), \E_USER_DEPRECATED);
+
+        $metadata = $this->getObjectManager()->getClassMetadata($this->class);
+        \assert($metadata instanceof ClassMetadataInfo);
+
+        return $metadata->table['name'];
     }
 
     public function clear(?string $objectName = null): void
@@ -142,7 +157,9 @@ abstract class BaseManager implements ManagerInterface, ClearableManagerInterfac
     /**
      * Returns the related Object Repository.
      *
-     * @return ObjectRepository
+     * @return ObjectRepository<object>
+     *
+     * @phpstan-return ObjectRepository<T>
      */
     protected function getRepository()
     {
@@ -150,9 +167,13 @@ abstract class BaseManager implements ManagerInterface, ClearableManagerInterfac
     }
 
     /**
+     * @param object $object
+     *
      * @throws \InvalidArgumentException
      *
      * @return void
+     *
+     * @phpstan-param T $object
      */
     protected function checkObject($object)
     {

--- a/src/Model/ManagerInterface.php
+++ b/src/Model/ManagerInterface.php
@@ -92,6 +92,8 @@ interface ManagerInterface
      * @param object $entity   The Entity to save
      * @param bool   $andFlush Flush the EntityManager after saving the object?
      *
+     * @return void
+     *
      * @phpstan-param T $entity
      */
     public function save($entity, $andFlush = true);
@@ -102,6 +104,8 @@ interface ManagerInterface
      * @param object $entity   The Entity to delete
      * @param bool   $andFlush Flush the EntityManager after deleting the object?
      *
+     * @return void
+     *
      * @phpstan-param T $entity
      */
     public function delete($entity, $andFlush = true);
@@ -109,12 +113,16 @@ interface ManagerInterface
     /**
      * Get the related table name.
      *
+     * NEXT_MAJOR: Remove this ORM-related method from the interface.
+     *
      * @return string
      */
     public function getTableName();
 
     /**
      * Get the DB driver connection.
+     *
+     * NEXT_MAJOR: Remove this ORM-related method from the interface.
      *
      * @return Connection
      */

--- a/src/Model/PageableManagerInterface.php
+++ b/src/Model/PageableManagerInterface.php
@@ -24,6 +24,8 @@ use Sonata\DatagridBundle\Pager\PagerInterface;
 /**
  * @author Raphaël Benitte <benitteraphael@gmail.com>
  *
+ * NEXT_MAJOR: Remove this interface.
+ *
  * @deprecated since 1.3, to be removed in 2.0. Use Sonata\DatagridBundle\Pager\PageableInterface instead.
  */
 interface PageableManagerInterface

--- a/src/Test/EntityManagerMockFactory.php
+++ b/src/Test/EntityManagerMockFactory.php
@@ -29,11 +29,15 @@ use PHPUnit\Framework\TestCase;
 );
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
  * @deprecated since sonata-project/doctrine-extensions 1.5, to be removed in 2.0.
  */
 class EntityManagerMockFactory
 {
     /**
+     * @param string[] $fields
+     *
      * @return EntityManagerInterface
      */
     public static function create(TestCase $test, \Closure $qbCallback, $fields)

--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -23,6 +23,8 @@ use Doctrine\DBAL\Types\Type;
 );
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
  * Convert a value into a json string to be stored into the persistency layer.
  */
 class JsonType extends Type

--- a/tests/Adapter/AdapterChainTest.php
+++ b/tests/Adapter/AdapterChainTest.php
@@ -19,7 +19,7 @@ use Sonata\Doctrine\Adapter\AdapterInterface;
 
 final class AdapterChainTest extends TestCase
 {
-    public function testEmptyAdapter()
+    public function testEmptyAdapter(): void
     {
         $adapter = new AdapterChain();
 
@@ -27,7 +27,7 @@ final class AdapterChainTest extends TestCase
         static::assertNull($adapter->getUrlSafeIdentifier(new \stdClass()));
     }
 
-    public function testUrlSafeIdentifier()
+    public function testUrlSafeIdentifier(): void
     {
         $adapter = new AdapterChain();
 
@@ -41,7 +41,7 @@ final class AdapterChainTest extends TestCase
         static::assertSame('voila', $adapter->getUrlSafeIdentifier(new \stdClass()));
     }
 
-    public function testNormalizedIdentifier()
+    public function testNormalizedIdentifier(): void
     {
         $adapter = new AdapterChain();
 

--- a/tests/Adapter/ORM/DoctrineORMAdapterTest.php
+++ b/tests/Adapter/ORM/DoctrineORMAdapterTest.php
@@ -43,6 +43,9 @@ final class DoctrineORMAdapterTest extends TestCase
         $adapter->getNormalizedIdentifier($entity);
     }
 
+    /**
+     * @return iterable<array-key, array{mixed}>
+     */
     public function getWrongEntities(): iterable
     {
         yield [0];
@@ -54,15 +57,23 @@ final class DoctrineORMAdapterTest extends TestCase
         yield ['sonata-project'];
     }
 
-    public function testNormalizedIdentifierWithNull()
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
+     * @psalm-suppress NullArgument
+     */
+    public function testNormalizedIdentifierWithNull(): void
     {
         $registry = $this->createMock(ManagerRegistry::class);
         $adapter = new DoctrineORMAdapter($registry);
 
+        // @phpstan-ignore-next-line
         static::assertNull($adapter->getNormalizedIdentifier(null));
     }
 
-    public function testNormalizedIdentifierWithNoManager()
+    public function testNormalizedIdentifierWithNoManager(): void
     {
         $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects(static::once())->method('getManagerForClass')->willReturn(null);
@@ -72,7 +83,7 @@ final class DoctrineORMAdapterTest extends TestCase
         static::assertNull($adapter->getNormalizedIdentifier(new \stdClass()));
     }
 
-    public function testNormalizedIdentifierWithNotManaged()
+    public function testNormalizedIdentifierWithNotManaged(): void
     {
         $unitOfWork = $this->getMockBuilder(UnitOfWork::class)->disableOriginalConstructor()->getMock();
         $unitOfWork->expects(static::once())->method('isInIdentityMap')->willReturn(false);
@@ -89,9 +100,11 @@ final class DoctrineORMAdapterTest extends TestCase
     }
 
     /**
+     * @param int[] $data
+     *
      * @dataProvider getFixtures
      */
-    public function testNormalizedIdentifierWithValidObject($data, $expected)
+    public function testNormalizedIdentifierWithValidObject(array $data, string $expected): void
     {
         $unitOfWork = $this->getMockBuilder(UnitOfWork::class)->disableOriginalConstructor()->getMock();
         $unitOfWork->expects(static::once())->method('isInIdentityMap')->willReturn(true);
@@ -108,7 +121,10 @@ final class DoctrineORMAdapterTest extends TestCase
         static::assertSame($expected, $adapter->getNormalizedIdentifier(new \stdClass()));
     }
 
-    public static function getFixtures()
+    /**
+     * @return iterable<array-key, array{array<int>, string}>
+     */
+    public function getFixtures(): iterable
     {
         return [
             [[1], '1'],

--- a/tests/Adapter/PHPCR/DoctrinePHPCRAdapterTest.php
+++ b/tests/Adapter/PHPCR/DoctrinePHPCRAdapterTest.php
@@ -20,8 +20,11 @@ use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Sonata\Doctrine\Adapter\PHPCR\DoctrinePHPCRAdapter;
 
-class MyDocument
+final class MyDocument
 {
+    /**
+     * @var mixed
+     */
     public $path;
 }
 
@@ -49,6 +52,9 @@ final class DoctrinePHPCRAdapterTest extends TestCase
         $adapter->getNormalizedIdentifier($document);
     }
 
+    /**
+     * @return iterable<array-key, array{mixed}>
+     */
     public function getWrongDocuments(): iterable
     {
         yield [0];
@@ -58,15 +64,23 @@ final class DoctrinePHPCRAdapterTest extends TestCase
         yield [[]];
     }
 
-    public function testNormalizedIdentifierWithNull()
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
+     * @psalm-suppress NullArgument
+     */
+    public function testNormalizedIdentifierWithNull(): void
     {
         $registry = $this->createMock(ManagerRegistry::class);
         $adapter = new DoctrinePHPCRAdapter($registry);
 
+        // @phpstan-ignore-next-line
         static::assertNull($adapter->getNormalizedIdentifier(null));
     }
 
-    public function testNormalizedIdentifierWithNoManager()
+    public function testNormalizedIdentifierWithNoManager(): void
     {
         $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects(static::once())->method('getManagerForClass')->willReturn(null);
@@ -76,7 +90,7 @@ final class DoctrinePHPCRAdapterTest extends TestCase
         static::assertNull($adapter->getNormalizedIdentifier(new \stdClass()));
     }
 
-    public function testNormalizedIdentifierWithNotManaged()
+    public function testNormalizedIdentifierWithNotManaged(): void
     {
         $manager = $this->getMockBuilder(DocumentManager::class)->disableOriginalConstructor()->getMock();
         $manager->expects(static::once())->method('contains')->willReturn(false);
@@ -92,7 +106,7 @@ final class DoctrinePHPCRAdapterTest extends TestCase
     /**
      * @dataProvider getFixtures
      */
-    public function testNormalizedIdentifierWithValidObject($data, $expected)
+    public function testNormalizedIdentifierWithValidObject(string $data, string $expected): void
     {
         $metadata = new ClassMetadata(MyDocument::class);
         $metadata->identifier = 'path';
@@ -114,7 +128,10 @@ final class DoctrinePHPCRAdapterTest extends TestCase
         static::assertSame($expected, $adapter->getUrlSafeIdentifier($instance));
     }
 
-    public static function getFixtures()
+    /**
+     * @return iterable<array-key, array{string, string}>
+     */
+    public static function getFixtures(): iterable
     {
         return [
             ['/salut', 'salut'],

--- a/tests/App/Entity/TestEntity.php
+++ b/tests/App/Entity/TestEntity.php
@@ -24,13 +24,20 @@ abstract class TestEntity
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
+     *
+     * @var int
      */
     private $id;
 
+    /**
+     * @var mixed
+     */
     private $relation;
 
     /**
      * @ORM\Column(type="string", length=200)
+     *
+     * @var string
      */
     private $property;
 }

--- a/tests/App/Entity/TestRelatedEntity.php
+++ b/tests/App/Entity/TestRelatedEntity.php
@@ -24,6 +24,8 @@ class TestRelatedEntity
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
+     *
+     * @var int
      */
     private $id;
 }

--- a/tests/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPassTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/Compiler/AdapterCompilerPassTest.php
@@ -29,7 +29,7 @@ final class AdapterCompilerPassTest extends AbstractCompilerPassTestCase
         $container->addCompilerPass(new AdapterCompilerPass());
     }
 
-    public function testDefinitionsAdded()
+    public function testDefinitionsAdded(): void
     {
         $adapterChain = new Definition();
         $this->setDefinition('sonata.doctrine.model.adapter.chain', $adapterChain);
@@ -54,7 +54,7 @@ final class AdapterCompilerPassTest extends AbstractCompilerPassTestCase
         );
     }
 
-    public function testDefinitionsAddedWithoutOrm()
+    public function testDefinitionsAddedWithoutOrm(): void
     {
         $adapterChain = new Definition();
         $this->setDefinition('sonata.doctrine.model.adapter.chain', $adapterChain);
@@ -74,7 +74,7 @@ final class AdapterCompilerPassTest extends AbstractCompilerPassTestCase
         );
     }
 
-    public function testDefinitionsRemoved()
+    public function testDefinitionsRemoved(): void
     {
         $adapterChain = new Definition();
         $this->setDefinition('sonata.doctrine.model.adapter.chain', $adapterChain);

--- a/tests/Bridge/Symfony/DependencyInjection/Compiler/MapperCompilerPassTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/Compiler/MapperCompilerPassTest.php
@@ -32,14 +32,14 @@ final class MapperCompilerPassTest extends AbstractCompilerPassTestCase
         $container->addCompilerPass(new MapperCompilerPass());
     }
 
-    public function testDefinitionsRemoved()
+    public function testDefinitionsRemoved(): void
     {
         $this->compile();
 
         $this->assertContainerBuilderNotHasService('sonata.doctrine.mapper');
     }
 
-    public function testDefinitionsRemovedWithMapper()
+    public function testDefinitionsRemovedWithMapper(): void
     {
         $this->registerService('sonata.doctrine.mapper', 'foo');
 
@@ -48,7 +48,7 @@ final class MapperCompilerPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderNotHasService('sonata.doctrine.mapper');
     }
 
-    public function testDefinitionsRemovedWithDoctrine()
+    public function testDefinitionsRemovedWithDoctrine(): void
     {
         $this->registerService('doctrine', 'foo');
 
@@ -57,7 +57,7 @@ final class MapperCompilerPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderNotHasService('sonata.doctrine.mapper');
     }
 
-    public function testDefinitionsNotRemoved()
+    public function testDefinitionsNotRemoved(): void
     {
         $this->registerService('sonata.doctrine.mapper', 'foo');
         $this->registerService('doctrine', 'foo');

--- a/tests/Document/BaseDocumentManagerTest.php
+++ b/tests/Document/BaseDocumentManagerTest.php
@@ -17,21 +17,24 @@ use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Sonata\Doctrine\Document\BaseDocumentManager;
 
-class DocumentManager extends BaseDocumentManager
+/**
+ * @phpstan-extends BaseDocumentManager<object>
+ */
+final class DocumentManager extends BaseDocumentManager
 {
 }
 
 final class BaseDocumentManagerTest extends TestCase
 {
-    public function getManager()
+    public function getManager(): DocumentManager
     {
         $registry = $this->createMock(ManagerRegistry::class);
 
-        return new DocumentManager('classname', $registry);
+        return new DocumentManager(\stdClass::class, $registry);
     }
 
-    public function test()
+    public function test(): void
     {
-        static::assertSame('classname', $this->getManager()->getClass());
+        static::assertSame(\stdClass::class, $this->getManager()->getClass());
     }
 }

--- a/tests/Entity/BaseEntityManagerTest.php
+++ b/tests/Entity/BaseEntityManagerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Doctrine\Tests\Entity;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
@@ -23,24 +24,24 @@ use Sonata\Doctrine\Entity\BaseEntityManager;
 final class BaseEntityManagerTest extends TestCase
 {
     /**
-     * @var ManagerRegistry|MockObject
+     * @var ManagerRegistry&MockObject
      */
     private $registry;
 
     /**
-     * @var ObjectManager|MockObject
+     * @var ObjectManager&MockObject
      */
     private $objectManager;
 
     /**
-     * @var BaseEntityManager
+     * @var BaseEntityManager<object>&MockObject
      */
     private $manager;
 
     protected function setUp(): void
     {
         $this->registry = $this->createMock(ManagerRegistry::class);
-        $this->objectManager = $this->createMock(ObjectManager::class);
+        $this->objectManager = $this->createMock(EntityManagerInterface::class);
         $this->manager = $this->getMockForAbstractClass(BaseEntityManager::class, ['classname', $this->registry]);
     }
 
@@ -49,11 +50,15 @@ final class BaseEntityManagerTest extends TestCase
         static::assertSame('classname', $this->manager->getClass());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     */
     public function testException(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The property exception does not exists');
 
+        // @phpstan-ignore-next-line
         $this->manager->exception;
     }
 
@@ -67,10 +72,16 @@ final class BaseEntityManagerTest extends TestCase
         $this->manager->getObjectManager();
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetEntityManager(): void
     {
         $this->registry->expects(static::once())->method('getManagerForClass')->willReturn($this->objectManager);
 
+        // @phpstan-ignore-next-line
         $this->manager->em;
     }
 

--- a/tests/Mapper/DoctrineCollectorTest.php
+++ b/tests/Mapper/DoctrineCollectorTest.php
@@ -51,7 +51,7 @@ class DoctrineCollectorTest extends TestCase
             ->add('columnDef', ''));
         $collector->addAssociation(\stdClass::class, 'type', OptionsBuilder::create()
             ->add('foo', 'bar'));
-        $collector->addDiscriminator(\stdClass::class, 'key', 'discriminatorClass');
+        $collector->addDiscriminator(\stdClass::class, 'key', \stdClass::class);
         $collector->addOverride(\stdClass::class, 'type', OptionsBuilder::create()
             ->add('foo', 'bar'));
 

--- a/tests/Mapper/ORM/DoctrineORMMapperTest.php
+++ b/tests/Mapper/ORM/DoctrineORMMapperTest.php
@@ -52,12 +52,15 @@ class DoctrineORMMapperTest extends KernelTestCase
     {
         self::bootKernel();
 
-        $mapper = self::$container->get('sonata.doctrine.mapper');
+        $mapper = self::getContainer()->get('sonata.doctrine.mapper');
 
         static::assertInstanceOf(DoctrineORMMapper::class, $mapper);
     }
 
-    protected static function getKernelClass()
+    /**
+     * @return class-string
+     */
+    protected static function getKernelClass(): string
     {
         return Kernel::class;
     }

--- a/tests/Mapper/ORM/DoctrineORMMapperTest.php
+++ b/tests/Mapper/ORM/DoctrineORMMapperTest.php
@@ -52,7 +52,7 @@ class DoctrineORMMapperTest extends KernelTestCase
     {
         self::bootKernel();
 
-        $mapper = self::getContainer()->get('sonata.doctrine.mapper');
+        $mapper = self::$container->get('sonata.doctrine.mapper');
 
         static::assertInstanceOf(DoctrineORMMapper::class, $mapper);
     }

--- a/tests/Model/BaseManagerTest.php
+++ b/tests/Model/BaseManagerTest.php
@@ -20,23 +20,19 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\Doctrine\Model\BaseManager;
 
+/**
+ * @phpstan-extends BaseManager<object>
+ */
 class ManagerTest extends BaseManager
 {
-    /**
-     * Get the DB driver connection.
-     *
-     * @return Connection
-     */
-    public function getConnection()
+    public function getConnection(): Connection
     {
+        throw new \BadMethodCallException('Not implemented');
     }
 
-    /**
-     * @param $object
-     */
-    public function publicCheckObject($object)
+    public function publicCheckObject(object $object): void
     {
-        return $this->checkObject($object);
+        $this->checkObject($object);
     }
 }
 
@@ -50,6 +46,11 @@ final class BaseManagerTest extends TestCase
      */
     private $objectManager;
 
+    /**
+     * @var ManagerTest
+     */
+    private $manager;
+
     protected function setUp(): void
     {
         $this->objectManager = $this->createMock(ObjectManager::class);
@@ -57,18 +58,18 @@ final class BaseManagerTest extends TestCase
         $managerRegistry = $this->createStub(ManagerRegistry::class);
         $managerRegistry->method('getManagerForClass')->willReturn($this->objectManager);
 
-        $this->manager = new ManagerTest('class', $managerRegistry);
+        $this->manager = new ManagerTest(\stdClass::class, $managerRegistry);
     }
 
-    public function testCheckObject()
+    public function testCheckObject(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Object must be instance of class, DateTime given');
+        $this->expectExceptionMessage('Object must be instance of stdClass, DateTime given');
 
         $this->manager->publicCheckObject(new \DateTime());
     }
 
-    public function testClearManager()
+    public function testClearManager(): void
     {
         $this->objectManager->expects(static::once())->method('clear');
 

--- a/tests/Types/JsonTypeTest.php
+++ b/tests/Types/JsonTypeTest.php
@@ -20,6 +20,8 @@ use PHPUnit\Framework\TestCase;
 use Sonata\Doctrine\Types\JsonType;
 
 /**
+ * NEXT_MAJOR: Remove this test.
+ *
  * @group legacy
  */
 class JsonTypeTest extends TestCase
@@ -33,7 +35,7 @@ class JsonTypeTest extends TestCase
         }
     }
 
-    public function testConvertToDatabaseValue()
+    public function testConvertToDatabaseValue(): void
     {
         $platform = new MockPlatform();
 
@@ -43,7 +45,7 @@ class JsonTypeTest extends TestCase
         );
     }
 
-    public function testConvertToPHPValue()
+    public function testConvertToPHPValue(): void
     {
         $platform = new MockPlatform();
 
@@ -59,32 +61,37 @@ class MockPlatform extends AbstractPlatform
     /**
      * Gets the SQL Snippet used to declare a BLOB column type.
      */
-    public function getBlobTypeDeclarationSQL(array $field)
+    public function getBlobTypeDeclarationSQL(array $column)
     {
         throw Exception::notSupported(__METHOD__);
     }
 
-    public function getBooleanTypeDeclarationSQL(array $columnDef)
+    public function getBooleanTypeDeclarationSQL(array $column)
     {
+        return '';
     }
 
-    public function getIntegerTypeDeclarationSQL(array $columnDef)
+    public function getIntegerTypeDeclarationSQL(array $column)
     {
+        return '';
     }
 
-    public function getBigIntTypeDeclarationSQL(array $columnDef)
+    public function getBigIntTypeDeclarationSQL(array $column)
     {
+        return '';
     }
 
-    public function getSmallIntTypeDeclarationSQL(array $columnDef)
+    public function getSmallIntTypeDeclarationSQL(array $column)
     {
+        return '';
     }
 
-    public function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
+    public function _getCommonIntegerTypeDeclarationSQL(array $column)
     {
+        return '';
     }
 
-    public function getVarcharTypeDeclarationSQL(array $field)
+    public function getVarcharTypeDeclarationSQL(array $column)
     {
         return 'DUMMYVARCHAR()';
     }
@@ -95,7 +102,7 @@ class MockPlatform extends AbstractPlatform
     }
 
     /** @override */
-    public function getClobTypeDeclarationSQL(array $field)
+    public function getClobTypeDeclarationSQL(array $column)
     {
         return 'DUMMYCLOB';
     }
@@ -116,5 +123,6 @@ class MockPlatform extends AbstractPlatform
 
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
+        return '';
     }
 }


### PR DESCRIPTION
## Subject

closes #236

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Passing null to `DoctrineORMAdapter::getNormalizedIdentifier()`
- Passing null to `DoctrineORMAdapter::getUrlSafeIdentifier()`
- Passing null to `DoctrinePHPCRAdapter::getNormalizedIdentifier()`
- Passing null to `DoctrinePHPCRAdapter::getUrlSafeIdentifier()`
- `BaseDocumentManager::__get()` method
- `BasePHPCRManager::__get()` method
- `BaseEntityManager::__get()` method
- `ManagerInterface::getTableName()` method
- `ManagerInterface::getConnection()` method
- `BaseManager::getTableName()` method
- `BasePHPCRManager::getTableName()` method
- `BasePHPCRManager::getConnection()` method
- `BaseEntityManager::getConnection()` method
- `BaseDocumentManager::getConnection()` method
```
