### PR TITLE
Add support for `doctrine/persistence` 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "doctrine/dbal": "^2.13 || ^3.1",
-        "doctrine/persistence": "^1.3.6 || ^2.0"
+        "doctrine/persistence": "^1.3.6 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "doctrine/common": "^2.7 || ^3.0",

--- a/src/Model/BaseManager.php
+++ b/src/Model/BaseManager.php
@@ -149,8 +149,21 @@ abstract class BaseManager implements ManagerInterface, ClearableManagerInterfac
         return $metadata->table['name'];
     }
 
+    /**
+     * NEXT_MAJOR: Remove $objectName parameter along with psalm and phpstan suppresions.
+     *
+     * @psalm-suppress TooManyArguments
+     */
     public function clear(?string $objectName = null): void
     {
+        if (\func_num_args() > 0) {
+            @trigger_error(sprintf(
+                'Passing an argument to "%s()" method is deprecated since sonata-project/sonata-doctrine-extensions 1.x.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
+        // @phpstan-ignore-next-line
         $this->getObjectManager()->clear($objectName);
     }
 

--- a/src/Model/BaseManager.php
+++ b/src/Model/BaseManager.php
@@ -150,7 +150,7 @@ abstract class BaseManager implements ManagerInterface, ClearableManagerInterfac
     }
 
     /**
-     * NEXT_MAJOR: Remove $objectName parameter along with psalm and phpstan suppresions.
+     * NEXT_MAJOR: Remove $objectName parameter and argument along with psalm and phpstan suppressions.
      *
      * @psalm-suppress TooManyArguments
      */

--- a/src/Model/ClearableManagerInterface.php
+++ b/src/Model/ClearableManagerInterface.php
@@ -19,6 +19,8 @@ namespace Sonata\Doctrine\Model;
 interface ClearableManagerInterface
 {
     /**
+     * NEXT_MAJOR: Remove $objectName parameter.
+     *
      * Clears the object manager for the given model.
      */
     public function clear(?string $objectName = null): void;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

It deprecates passing an argument to `ClearableManagerInterface::clear` to be in sync with [`ObjectManager::clear`](https://github.com/doctrine/persistence/blob/25ec98a8cbd1f850e60fdb62c0ef77c162da8704/UPGRADE.md#bc-break-changed-signatures).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #407.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for `doctrine/persistence` 3
### Deprecated
- Deprecated passing an argument to `ClearableManagerInterface::clear()`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
