### PR TITLE
Drop support of Symfony 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,10 @@
         "phpunit/phpunit": "^9.5.13",
         "psalm/plugin-phpunit": "^0.16",
         "rector/rector": "^0.12",
-        "symfony/dependency-injection": "^4.4 || ^5.3 || ^6.0",
-        "symfony/expression-language": "^4.4 || ^5.3 || ^6.0",
-        "symfony/framework-bundle": "^4.4 || ^5.3 || ^6.0",
-        "symfony/phpunit-bridge": "^6.0",
+        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
+        "symfony/expression-language": "^4.4 || ^5.4 || ^6.0",
+        "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",
+        "symfony/phpunit-bridge": "^6.1",
         "vimeo/psalm": "^4.1"
     },
     "conflict": {


### PR DESCRIPTION
## Subject

Support only maintained versions of Symfony

I am targeting this branch, because these changes are BC.

## Changelog

```markdown
### Removed
- Support of Symfony 5.3
```