### PR TITLE
Return null in JsonType

### DIFF
--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -29,11 +29,17 @@ class JsonType extends Type
 
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
+        if ($value === null) {
+            return null;
+        }
         return json_decode((string) $value, true, 512, \JSON_THROW_ON_ERROR);
     }
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
+        if ($value === null) {
+            return null;
+        }
         return json_encode($value, \JSON_THROW_ON_ERROR);
     }
 

--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -29,17 +29,19 @@ class JsonType extends Type
 
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null) {
+        if (null === $value) {
             return null;
         }
+
         return json_decode((string) $value, true, 512, \JSON_THROW_ON_ERROR);
     }
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        if ($value === null) {
+        if (null === $value) {
             return null;
         }
+
         return json_encode($value, \JSON_THROW_ON_ERROR);
     }
 

--- a/tests/Types/JsonTypeTest.php
+++ b/tests/Types/JsonTypeTest.php
@@ -43,6 +43,11 @@ class JsonTypeTest extends TestCase
             '{"foo":"bar"}',
             Type::getType('json')->convertToDatabaseValue(['foo' => 'bar'], $platform)
         );
+
+        static::assertSame(
+            null,
+            Type::getType('json')->convertToDatabaseValue(null, $platform)
+        );
     }
 
     public function testConvertToPHPValue(): void
@@ -52,6 +57,11 @@ class JsonTypeTest extends TestCase
         static::assertSame(
             ['foo' => 'bar'],
             Type::getType('json')->convertToPHPValue('{"foo":"bar"}', $platform)
+        );
+
+        static::assertSame(
+            null,
+            Type::getType('json')->convertToPHPValue(null, $platform)
         );
     }
 }

--- a/tests/Types/JsonTypeTest.php
+++ b/tests/Types/JsonTypeTest.php
@@ -44,8 +44,7 @@ class JsonTypeTest extends TestCase
             Type::getType('json')->convertToDatabaseValue(['foo' => 'bar'], $platform)
         );
 
-        static::assertSame(
-            null,
+        static::assertNull(
             Type::getType('json')->convertToDatabaseValue(null, $platform)
         );
     }
@@ -59,8 +58,7 @@ class JsonTypeTest extends TestCase
             Type::getType('json')->convertToPHPValue('{"foo":"bar"}', $platform)
         );
 
-        static::assertSame(
-            null,
+        static::assertNull(
             Type::getType('json')->convertToPHPValue(null, $platform)
         );
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Return null if json field is null instance of throwing an error

In commit https://github.com/sonata-project/sonata-doctrine-extensions/commit/8a4cd230ae0939f4984151bb725abfc47dbae351 there was added `\JSON_THROW_ON_ERROR` flag to `json_decode` function, so our code is broken because json column can contain `null`:
```
In JsonType.php line 32:
                
  Syntax error  
```
Impossible to migrate to v2, because current php version is 7.4. We are working on migration...

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog
<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- JsonType::convertToPHPValue and JsonType::convertToDatabaseValue can return null 
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
