### PR TITLE
Load mapping earlier

### DIFF
--- a/src/Bridge/Symfony/Resources/config/mapper_orm.php
+++ b/src/Bridge/Symfony/Resources/config/mapper_orm.php
@@ -19,5 +19,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->services()
 
         ->set('sonata.doctrine.mapper', DoctrineORMMapper::class)
-            ->tag('doctrine.event_listener', ['event' => 'loadClassMetadata']);
+            ->tag('doctrine.event_listener', ['event' => 'loadClassMetadata', 'priority' => 10]);
 };

--- a/src/Mapper/DoctrineCollector.php
+++ b/src/Mapper/DoctrineCollector.php
@@ -253,7 +253,7 @@ final class DoctrineCollector
     {
         foreach ($columns as $column) {
             if (!\is_string($column)) {
-                throw new \InvalidArgumentException(sprintf('The column is not a valid string, %s given', \gettype($column)));
+                throw new \InvalidArgumentException(\sprintf('The column is not a valid string, %s given', \gettype($column)));
             }
         }
     }

--- a/src/Mapper/ORM/DoctrineORMMapper.php
+++ b/src/Mapper/ORM/DoctrineORMMapper.php
@@ -237,7 +237,7 @@ final class DoctrineORMMapper implements EventSubscriber
                 }
             }
         } catch (\ReflectionException $e) {
-            throw new \RuntimeException(sprintf('Error with class %s : %s', $metadata->getName(), $e->getMessage()), 404, $e);
+            throw new \RuntimeException(\sprintf('Error with class %s : %s', $metadata->getName(), $e->getMessage()), 404, $e);
         }
     }
 
@@ -268,7 +268,7 @@ final class DoctrineORMMapper implements EventSubscriber
                 $metadata->setDiscriminatorColumn($arrayDiscriminatorColumns);
             }
         } catch (\ReflectionException $e) {
-            throw new \RuntimeException(sprintf('Error with class %s : %s', $metadata->getName(), $e->getMessage()), 404, $e);
+            throw new \RuntimeException(\sprintf('Error with class %s : %s', $metadata->getName(), $e->getMessage()), 404, $e);
         }
     }
 
@@ -290,7 +290,7 @@ final class DoctrineORMMapper implements EventSubscriber
                 $metadata->setInheritanceType($this->inheritanceTypes[$metadata->getName()]);
             }
         } catch (\ReflectionException $e) {
-            throw new \RuntimeException(sprintf('Error with class %s : %s', $metadata->getName(), $e->getMessage()), 404, $e);
+            throw new \RuntimeException(\sprintf('Error with class %s : %s', $metadata->getName(), $e->getMessage()), 404, $e);
         }
     }
 
@@ -315,7 +315,7 @@ final class DoctrineORMMapper implements EventSubscriber
                 $metadata->setDiscriminatorMap([$key => $class]);
             }
         } catch (\ReflectionException $e) {
-            throw new \RuntimeException(sprintf('Error with class %s : %s', $metadata->getName(), $e->getMessage()), 404, $e);
+            throw new \RuntimeException(\sprintf('Error with class %s : %s', $metadata->getName(), $e->getMessage()), 404, $e);
         }
     }
 
@@ -369,7 +369,7 @@ final class DoctrineORMMapper implements EventSubscriber
             }
         } catch (\ReflectionException $e) {
             throw new \RuntimeException(
-                sprintf('Error with class %s : %s', $metadata->getName(), $e->getMessage()),
+                \sprintf('Error with class %s : %s', $metadata->getName(), $e->getMessage()),
                 404,
                 $e
             );
@@ -383,7 +383,7 @@ final class DoctrineORMMapper implements EventSubscriber
     {
         foreach ($columns as $column) {
             if (!\is_string($column)) {
-                throw new \InvalidArgumentException(sprintf('The column is not a valid string, %s given', \gettype($column)));
+                throw new \InvalidArgumentException(\sprintf('The column is not a valid string, %s given', \gettype($column)));
             }
         }
     }

--- a/src/Model/BaseManager.php
+++ b/src/Model/BaseManager.php
@@ -111,7 +111,7 @@ abstract class BaseManager implements ManagerInterface, ClearableManagerInterfac
     protected function checkObject(object $object): void
     {
         if (!$object instanceof $this->class) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new \InvalidArgumentException(\sprintf(
                 'Object must be instance of %s, %s given',
                 $this->class,
                 get_debug_type($object)
@@ -127,7 +127,7 @@ abstract class BaseManager implements ManagerInterface, ClearableManagerInterfac
         $manager = $this->registry->getManagerForClass($this->class);
 
         if (null === $manager) {
-            throw new \RuntimeException(sprintf(
+            throw new \RuntimeException(\sprintf(
                 'Unable to find the mapping information for the class %s.'
                 .' Please check the `auto_mapping` option'
                 .' (http://symfony.com/doc/current/reference/configuration/doctrine.html#configuration-overview)'


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Changed
 - Load mapping earlier (priority 10)
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
There is a problem if you want to the the doctrine extensions together with [gedmo sluggable](https://github.com/doctrine-extensions/DoctrineExtensions/blob/93d8133202e890ae323645e97ce83a9623f8ec7a/src/Sluggable/SluggableListener.php#L133), because both `loadClassMetadata` event listener will run at the default priority (0).

--- 
The problem can be reproduced when defining a mapping using sonata:
```php
        $collector = DoctrineCollector::getInstance();

        $collector->addAssociation(
            'role_table',
            self::MAP_MANY_TO_ONE,
            OptionsBuilder::createManyToOne('topic', 'topic_table')
                ->cascade(['persist'])
                ->addJoin([
                    'name'                 => 'topic_id',
                    'referencedColumnName' => 'id',
                    'nullable'             => false,
                    'onDelete'             => 'CASCADE',
                ])
        );
```

and having a entity mapping:
```php
namespace App\Entity;

class Role {

    #[Gedmo\Slug(fields: ['name'], updatable: false, separator: '_', unique_base: 'topic')]
    protected ?string $slug = null;

   // ...
}
```

You receive an error:
```
  Unable to find [topic] as mapped property in entity - App\Entity\Role
```
